### PR TITLE
chore: adopt the project issue-reporting standard and protect main

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+#
+# Reject commit messages that carry AI/assistant attribution.
+#
+# This project does not want Co-Authored-By trailers naming an AI assistant, nor
+# "Generated with Claude Code"-style signatures, in its history. See the matching
+# CI guard in .github/workflows/no-attribution.yml — keep the pattern in sync.
+#
+# Installed for everyone via the package.json "prepare" script, which points
+# git at this directory (`git config core.hooksPath .githooks`) on `npm install`.
+
+msg_file="$1"
+
+# Scan only the real message: drop the diff appended by `commit --verbose` (from
+# the scissors comment onward) and strip remaining comment lines.
+content="$(sed '/^#.*>8/,$d' "$msg_file" | grep -v '^#')"
+
+# Anchored to the start of a line: real attribution is a trailer / signature at
+# column 0, so prose that merely *mentions* these phrases mid-sentence (e.g. this
+# hook's own docs) does not trip it. The generated-with branch tolerates a
+# leading emoji/space.
+pattern='^[[:space:]]*co-authored-by:.*(claude|anthropic)|^[^[:alpha:]]*generated with .*claude code'
+
+if printf '%s\n' "$content" | grep -iEq "$pattern"; then
+    echo "commit-msg: AI/assistant attribution is not allowed in commit messages." >&2
+    printf '%s\n' "$content" | grep -iEn "$pattern" | sed 's/^/    /' >&2
+    echo "Remove the 'Co-Authored-By: …' / 'Generated with Claude Code' line and commit again." >&2
+    exit 1
+fi
+
+exit 0

--- a/.github/ISSUE_REPORTING.md
+++ b/.github/ISSUE_REPORTING.md
@@ -353,7 +353,8 @@ tracker.
 | `Song-of-Heroic-Lands-FoundryVTT` | The Foundry system code, the `sohl` package's content, and the system build |
 | `sohl-thalorna`                   | The `thalorna` package — original setting content and the `/thalorna` site  |
 | `sohl-kethira-basic`              | **This repository** — the `kethira` package, Foundry compendium packs only  |
-| `heroiclands-site`                | heroiclands.org — the Hugo site, Cloudflare Pages, the CDN                  |
+| `heroiclands-site`                | heroiclands.org — its content, Cloudflare Pages, the CDN                    |
+| `heroiclands-hugo-theme`          | The shared Hugo theme the project's sites render through                    |
 
 **File the issue where the work will be done.** The rule is delivery, not subject: if
 the fix is an edit to a file in this repository, the issue belongs here, even when the

--- a/.github/ISSUE_REPORTING.md
+++ b/.github/ISSUE_REPORTING.md
@@ -1,0 +1,392 @@
+# Issue Reporting — sohl-kethira-basic
+
+This document defines how issues are created and classified in the
+**`sohl-kethira-basic`** repository, which ships the `kethira` package: unofficial
+Hârn fan material, as Foundry compendium packs and nothing else.
+
+**This repository is its own tracker.** File Kethira work here, not in the system
+repository. See §9 for where a given piece of work belongs.
+
+> **This repository is a carve-out.** It is unofficial Hârn fan material under
+> Keléstia's Fan Material Guidelines, licensed separately from SoHL, and nothing
+> elsewhere in the project may depend on it — it must stay withdrawable without
+> affecting the system or any other package. Keep that in view when scoping an
+> issue: work that would create a dependency **on** this repository from another one
+> is out of scope here, and belongs as a discussion before it becomes an issue
+> anywhere.
+
+The core discipline is simple — four axes, each answering a different question:
+
+- **Type** — _"what shape of work is this?"_ One per issue, from a closed set of five.
+- **Priority** — _"how soon and how badly does this need doing?"_ A GitHub issue field, one value, defaults to Medium.
+- **Labels** — _"what is this about?"_ Categorization only, chosen **only** from the registry below. Never invent a label.
+- **Milestone** — _"which capability gate does this advance?"_ A native GitHub milestone (no due date), at most one, selected from a curated set (see §4).
+
+Type, priority, and milestone are structured single values (one each). Labels
+stack. Keep the roles separate: do not encode priority, urgency, or work-shape as a
+label; do not encode subject matter as a type; and do not encode a capability gate
+as a label when a milestone is its proper home.
+
+## 1. Issue types
+
+Exactly **one** type per issue. Choose using the decision procedure in §5 when in
+doubt. Do not leave an issue untyped.
+
+Issue types are **organization-level** in the `HeroicLands` org, so the same five
+types — and their definitions — are shared with every other repository in the
+project. They are not redefined here.
+
+| Type        | Use it when…                                                                                                                                                        | Do **not** use it for…                                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **bug**     | Existing, shipped behavior is wrong or broken relative to what it should do — an error, crash, incorrect result, or regression.                                     | Missing capability (that's a _feature_); known-incomplete work in progress; a chore.                                   |
+| **feature** | A new capability or enhancement that does not exist yet, deliverable as one shippable unit of value.                                                                | Anything broken (_bug_); work large enough to need many sub-issues (_epic_); pure maintenance (_task_).                |
+| **epic**    | A large body of work that only makes sense decomposed into multiple sub-issues; a coordinating container tracked by its children.                                   | Anything you can ship as a single issue. If it has no sub-issues, it is not an epic.                                   |
+| **task**    | Necessary work that is neither a defect nor a new capability: chores, maintenance, refactors, dependency bumps, tooling, docs, releases. May or may not touch code. | Work whose outcome is uncertain and exploratory (_spike_); a defect (_bug_).                                           |
+| **spike**   | A **timeboxed** investigation whose deliverable is a _decision, answer, or recommendation_ — not shipped code. Outcome is genuinely uncertain going in.             | Work whose steps are already known (that's a _task_). A spike that produces code instead of a conclusion was mistyped. |
+
+**Type rules**
+
+- **MUST** assign exactly one type.
+- A **bug** is _broken_; a **feature** is _missing_. That distinction resolves most ambiguity — decide which word fits before anything else.
+- An **epic** MUST link its sub-issues (native GitHub sub-issues; see §6) and SHOULD carry little implementation detail of its own. Its acceptance is "all sub-issues closed and the whole verified together."
+- A **spike** MUST state (a) the question it answers and (b) its timebox. It closes when the question is answered, and it typically _spawns_ follow-up feature/task/bug issues rather than doing the work itself.
+- A **refactor** that changes no external behavior is a **task**, tagged `tech-debt` — it is not a feature and not a bug.
+
+**What "broken" means for content.** This repository ships prose and data, not
+running code, so a bug is usually a wrong or unloadable _fact_: a dead link, a
+shortcode collision, a note that fails to compile into its pack, an entry whose
+document ID moved under an existing world. A note that is merely thin or unwritten
+is not broken — that is a **feature** (the material is missing) or a **task** (it is
+scheduled work).
+
+**A licence problem is a bug.** Shipping third-party art, trade dress, or verbatim
+rulebook text is broken behavior, not a missing feature — file it as a **bug**, and
+prioritize it by exposure rather than by effort.
+
+## 2. Priority (GitHub issue field)
+
+Priority is a native **Priority** field on the issue itself — an
+organization-level issue field, **not** a label and **not** tied to a Project. Set
+it in the issue sidebar; the repo issue list filters on it
+(`field.priority:high,medium`), and it is read/written through the GitHub issue
+API. One value per issue, from: **Urgent · High · Medium · Low**.
+
+Priority is about attention, not schedule — this project has no deadlines, so
+priority answers "when I next sit down, what deserves my time?" not "what is due."
+
+| Priority   | Meaning                                                      | Typical triggers                                                                                                                                       |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Urgent** | Do it next session. Active harm or a hard blocker.           | Content loss or corruption; packs that will not compile, so nothing ships; the published site is down or serving wrong pages; blocks the current gate. |
+| **High**   | Wanted soon; the current gate leans on it.                   | A published address broken with no redirect; work the active milestone depends on.                                                                     |
+| **Medium** | **Default.** Should get done; not blocking the current gate. | Most content and tooling work; defects with a workaround.                                                                                              |
+| **Low**    | Deferrable indefinitely with little cost.                    | Cosmetic issues; nice-to-haves; long-tail edge cases; opportunistic cleanup.                                                                           |
+
+**Priority rules**
+
+- **MUST** set a priority on every issue.
+- **Default to Medium.** Anything higher MUST be justified in the body (one line: why the impact warrants it). Do not inflate — not everything is High.
+- Priority is independent of type, labels, **and** milestone. A `security`-labelled issue is **not** automatically Urgent: hardening with no known exploit can be Low; an exploit in the wild is Urgent. Judge impact, not the topic.
+- An **epic**'s priority reflects the initiative's importance, not the max of its children.
+
+## 3. Labels — the closed registry
+
+Labels are for **categorization only**. The table below is the **complete,
+authoritative set for this repository**. Its machine-readable twin is
+`.github/labels.yml`, which the `labels-sync` workflow reconciles onto GitHub (the
+set is _closed_ — a label not in the registry is deleted on sync). `npm run
+lint:labels` fails if the two disagree (`check-labels`), so they cannot drift.
+
+> **MUST NOT invent, rename, or improvise labels.** If no existing label fits, add
+> none and (if it matters) note the gap in the issue body for a maintainer to decide.
+> Extending this registry is a deliberate decision made by editing **both** this
+> table and `.github/labels.yml`, not something done at filing time.
+
+**This registry is the narrowest in the project, on purpose.** Each repository's
+registry describes only what that repository can hold. `system`, `tests`, `site`,
+and `thalorna` are absent here: this repository ships no system code, no test
+suite, and no website, and every issue in it is Kethira by definition.
+
+| Label             | Scope                                                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `content`         | Kethira material — notes, compendium packs, actors, items, journals, scenes, artwork.                                        |
+| `documentation`   | Documentation about this repository — README, CLAUDE.md, process, authoring guides.                                          |
+| `devops`          | Build, tooling, pack pipeline, release, repo config.                                                                         |
+| `security`        | Touches an attack surface: data integrity, macro/script execution, injection, or anything warranting private disclosure (§7). |
+| `tech-debt`       | Restructuring or cleanup of working content or tooling; refactors.                                                           |
+| `regression`      | Something that previously worked and stopped. Pairs with type `bug`.                                                         |
+| `breaking-change` | Alters a shortcode, document ID, or pack compatibility in a way existing worlds will notice.                                 |
+| `blocked`         | Cannot proceed until an external dependency or another issue clears.                                                         |
+| `duplicate`       | This issue or pull request already exists.                                                                                   |
+| `question`        | Further information is requested.                                                                                            |
+| `wontfix`         | This will not be worked on.                                                                                                  |
+
+> **No capability-gate labels.** Progress toward a capability is tracked by
+> **milestones** (§4), not labels. Do not add `bestiary`-style or `v1.0`-style labels
+> to mark what a milestone already carries.
+
+**Label rules**
+
+- Choose labels **only** from this file. No exceptions.
+- Labels are additive and orthogonal — `content` + `devops` + `regression` on one bug is fine.
+- Do not use a label to express something a type, the priority field, or a milestone already expresses.
+
+## 4. Milestones — capability gates
+
+Milestones here are **capability gates, not calendar dates.** Each milestone is a
+demonstrable threshold the package crosses — a state you can point at and say "it
+does this now" — and **crossing a gate is what triggers a release.** This project is
+not date-driven and has no deadlines, and GitHub supports that directly: a
+milestone's due date is optional, and its progress bar is computed from the ratio of
+closed to open issues, not from any date. Leave due dates blank.
+
+**Name milestones by the capability reached,** phrased as a state of the package —
+"the core bestiary is playable", "the western kingdoms are covered" — rather than by a
+date or a version number alone. If you want the order explicit, encode it in the
+name (`M1 · …`, `M2 · …`); otherwise let the list carry it.
+
+**An issue's milestone is the gate its work advances.** When every issue in a
+milestone is closed, the package has crossed that gate. One milestone per issue
+(GitHub enforces this); if an issue seems to serve two gates, it usually belongs to
+the earlier one or is scoped too large.
+
+**Milestone vs. epic — different lenses, keep them straight:**
+
+|           | **Epic** (a type)                          | **Milestone** (a gate)                       |
+| --------- | ------------------------------------------ | -------------------------------------------- |
+| Groups by | work breakdown — a tree of sub-issues      | outcome — a capability the package gains     |
+| Answers   | "what are all the pieces of _this build_?" | "how close is it to _doing this thing_?"     |
+| Done when | all its sub-issues are closed              | all issues tagged to it are closed           |
+| Shape     | vertical: one initiative, decomposed       | horizontal: a slice across the whole package |
+
+**The milestone set is curated, like the label registry** — select from existing
+gates and never invent one.
+
+- You MAY assign an issue to a milestone when its work **unambiguously advances exactly one existing gate**.
+- Leave the milestone **unset** when the issue advances none of the current gates (it is future/backlog), spans several, or the mapping is unclear. An unset milestone is a normal, correct state.
+- You MUST NOT create a new milestone. If no gate fits and one seems warranted, note it in the body and raise it for awareness.
+
+**This repository currently defines no milestones.** That is deliberate, not an
+oversight: gates are named when the maintainer knows which capability the package is
+driving at, and until then every issue's milestone is correctly unset. Do not invent
+one to fill the field.
+
+### Milestones and releases
+
+**Reaching a gate is what cuts a release.** When every issue in a milestone is
+closed, the package has demonstrably gained that capability — and that is the
+trigger to cut a new release, versioned for the capability reached, not for any
+date. There is no release calendar and no due dates: releases are **paced by
+capability**, so the milestone progress bar is the only schedule the project keeps.
+
+## 5. Choosing the type — decision procedure
+
+Walk this in order; take the first match.
+
+1. Is something **broken** relative to intended behavior? → **bug** (add `regression` if it used to work).
+2. Is the outcome **genuinely uncertain** and the deliverable a **decision/answer**? → **spike** (state question + timebox).
+3. Is this too large to ship as one issue, needing **multiple sub-issues** to coordinate? → **epic**.
+4. Is it a **new capability or enhancement** that doesn't exist yet? → **feature**.
+5. Otherwise — chore, maintenance, refactor, docs, tooling, release? → **task**.
+
+Then, regardless of type: set **priority** (default Medium; justify higher), apply
+any **labels** from §3 that categorize it, and set a **milestone** only when the issue
+clearly advances one existing capability gate (§4) — otherwise leave it unset.
+
+## 6. Body structure by type
+
+Titles: imperative and specific. "Fix the deity pack referencing a retired
+shortcode," not "link bug." No trailing punctuation.
+
+Every issue body should give enough context that someone with repo familiarity but
+no memory of the conversation can act on it. Use the shape for its type — the issue
+forms in `.github/ISSUE_TEMPLATE/` pre-fill each of these.
+
+### Bug
+
+Bugs should describe the problem as fully as possible, so it may be easily
+reproduced. The description should NOT contain a description of how to fix the
+issue. Suggestions for fixes or approaches may be placed in comments.
+
+**Acceptance criteria** is optional.
+
+```
+## Summary
+One sentence: what's wrong.
+
+## Steps to reproduce
+1. …
+2. …
+
+## Expected vs. actual
+Expected: …
+Actual: …
+
+## Acceptance criteria
+- [ ] Observable condition 1
+- [ ] Observable condition 2
+
+## Environment
+Foundry version · SoHL system version · module version · browser/OS if relevant
+
+## Notes
+Stack traces, console output, suspected cause.
+```
+
+### Feature
+
+```
+## Problem / motivation
+What need or gap this addresses.
+
+## Proposed solution
+What to build. Sketch the approach if known.
+
+## Acceptance criteria
+- [ ] Observable condition 1
+- [ ] Observable condition 2
+```
+
+### Epic
+
+```
+## Goal
+The outcome this initiative delivers.
+
+## Scope
+In scope / out of scope.
+
+## Sub-issues
+(Linked as native sub-issues; list mirrors them.)
+- [ ] #…
+- [ ] #…
+
+## Done when
+All sub-issues closed and integration verified.
+```
+
+### Task
+
+```
+## What
+The work to be done.
+
+## Why
+The reason it's needed (keeps chores from looking arbitrary).
+```
+
+### Spike
+
+```
+## Question
+The specific thing we need to decide or learn.
+
+## Timebox
+e.g. 1 day / 4 hours. MUST be present.
+
+## Deliverable
+The form of the answer: a decision, a recommendation, a written finding,
+a prototype-to-throw-away. NOT production code.
+
+## Follow-up
+Note that follow-up feature/task/bug issues will be filed from the outcome.
+```
+
+## 7. Security issues — special handling
+
+If an issue would be labelled `security` **and** describes an exploitable weakness
+(not merely hardening), **do not open a public issue**. Use GitHub's private
+security advisories / vulnerability reporting instead — the "Report a
+vulnerability" button on this repository's Security tab, also linked from the issue
+chooser. This package ships into users' Foundry instances, so a macro-injection or
+data-execution path in shipped content has a real (if small) attack surface. When in
+doubt, disclose privately and let a maintainer decide whether to make it public.
+
+A **licence** problem is not a security problem and does not go to an advisory —
+file it as a public `bug`.
+
+## 8. Worked examples
+
+**Bug, Urgent**
+
+> **Title:** Replace the Keléstia deity sigils still shipped in the pantheon pack
+> **Type:** bug · **Priority:** Urgent · **Labels:** `content` · **Milestone:** _(unset)_
+> Body: third-party art is shipping in a released pack — a licence breach with active exposure → Urgent.
+
+**Bug, Medium, regression**
+
+> **Title:** Fix the bestiary pack failing to compile after the shortcode charset change
+> **Type:** bug · **Priority:** Medium · **Labels:** `content`, `devops`, `regression` · **Milestone:** _(unset)_
+> Body: compiled before, does not now; a local workaround exists → Medium.
+
+**Feature, Medium**
+
+> **Title:** Add the western kingdoms regional entries
+> **Type:** feature · **Priority:** Medium · **Labels:** `content` · **Milestone:** _(unset)_
+> Body: material that does not exist yet, shippable as one unit → Medium.
+
+**Epic, Medium**
+
+> **Title:** Cover the core bestiary
+> **Type:** epic · **Priority:** Medium · **Labels:** `content`
+> Body: coordinates a tree of sub-issues (one per creature family), each filed separately and linked.
+
+**Task, Low**
+
+> **Title:** Bump @heroiclands/content-build to the current release
+> **Type:** task · **Priority:** Low · **Labels:** `devops` · **Milestone:** _(unset)_
+> Body: routine maintenance, deferrable → Low.
+
+**Spike, Medium**
+
+> **Title:** Decide how far this module may reference sohl package content
+> **Type:** spike · **Priority:** Medium · **Labels:** `content`
+> Body: **Question** — which cross-package references keep the carve-out withdrawable? **Timebox** — 4 hours. **Deliverable** — a written rule. Follow-up issues filed from the finding.
+
+## 9. Which repository does an issue belong in?
+
+The project spans several repositories in the `HeroicLands` organization, and — as
+of the process split — **each one tracks its own work.** There is no central
+tracker.
+
+| Repository                        | Tracks                                                                      |
+| --------------------------------- | --------------------------------------------------------------------------- |
+| `Song-of-Heroic-Lands-FoundryVTT` | The Foundry system code, the `sohl` package's content, and the system build |
+| `sohl-thalorna`                   | The `thalorna` package — original setting content and the `/thalorna` site  |
+| `sohl-kethira-basic`              | **This repository** — the `kethira` package, Foundry compendium packs only  |
+| `heroiclands-site`                | heroiclands.org — the Hugo site, Cloudflare Pages, the CDN                  |
+
+**File the issue where the work will be done.** The rule is delivery, not subject: if
+the fix is an edit to a file in this repository, the issue belongs here, even when the
+symptom shows up elsewhere. A Kethira item that loads wrong because the **system**
+mishandles its data model is a system issue; the same item loading wrong because its
+own frontmatter is malformed is an issue here.
+
+**Nothing outside this repository may depend on it.** If an issue here would require a
+change in the system or another package to land first, that is a signal the carve-out
+is being eroded — say so in the body rather than filing the dependent issue there.
+
+**When work genuinely spans two repositories, file in each and link them.** Cross-repo
+references work fine (`HeroicLands/<repo>#123`); what does **not** work is closing:
+
+> **Closing keywords do not cross repositories.** A pull request here carrying
+> `Closes HeroicLands/Song-of-Heroic-Lands-FoundryVTT#123` creates a reference but
+> **does not close** that issue — GitHub only auto-closes within the same repository.
+> A cross-repository issue is **closed by hand**, with a comment linking the delivering
+> commit or pull request. Never assume the keyword did it; check.
+
+**Historical note.** Until 2026-08-20 this repository's work was tracked informally in
+`Song-of-Heroic-Lands-FoundryVTT`. It now tracks its own.
+
+## Self-check before filing
+
+You should confirm all of these before submitting an issue:
+
+- [ ] This is the right repository (§9) — the work will be delivered here.
+- [ ] Exactly **one type** assigned, chosen via the §5 procedure.
+- [ ] A **priority** is set. If above Medium, the body justifies it in one line.
+- [ ] Every label comes from the §3 registry. **Zero** invented labels.
+- [ ] No label duplicates what the type, priority field, or milestone already says.
+- [ ] **Milestone** set only when the issue clearly advances one existing capability gate (§4); otherwise unset. **Never** invented.
+- [ ] Title is imperative and specific; body follows the §6 shape for its type. Title should not encode labels or other field information.
+- [ ] If `security` + exploitable → routed to **private advisory**, not a public issue (§7).
+- [ ] If **epic** → sub-issues are linked. If **spike** → question and timebox are present.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,32 @@
+name: Bug
+description: Existing behavior is broken — an error, crash, wrong result, or regression.
+type: Bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the problem fully so it can be reproduced. Do not propose a fix here — put fix ideas in a comment. Exploitable weaknesses must be reported privately, never as a public issue.
+      value: |
+        ## Summary
+        One sentence: what's wrong.
+
+        ## Steps to reproduce
+        1. …
+        2. …
+
+        ## Expected vs. actual
+        Expected: …
+        Actual: …
+
+        ## Acceptance criteria
+        - [ ] Observable condition 1
+        - [ ] Observable condition 2
+
+        ## Environment
+        Foundry version · SoHL system version · module version · browser/OS if relevant
+
+        ## Notes
+        Stack traces, console output, suspected cause.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Report a security vulnerability (private)
+      url: https://github.com/HeroicLands/sohl-kethira-basic/security/advisories/new
+      about: Exploitable weaknesses must be reported privately as a security advisory — never as a public issue. See the Security Policy and issue-reporting §7.
+    - name: An issue with the SoHL system itself
+      url: https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/issues/new/choose
+      about: This tracker is for the Kethira content module. System code, sheets, and rules automation are tracked in the system repository.
+    - name: Question or discussion
+      url: https://bit.ly/44vZ10j
+      about: For questions and general discussion, use the SoHL Discord.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,41 @@
+name: Epic
+description: A large body of work that only makes sense decomposed into multiple linked sub-issues.
+type: Epic
+body:
+  - type: markdown
+    attributes:
+      value: |
+        An **epic** coordinates a tree of sub-issues and carries little implementation detail of its own. If it has no sub-issues, it is **not** an epic — file a feature or task instead. See the [issue-reporting standard](https://github.com/HeroicLands/sohl-kethira-basic/blob/main/.github/ISSUE_REPORTING.md).
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: The outcome this initiative delivers.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      placeholder: |
+        In scope: …
+        Out of scope: …
+    validations:
+      required: true
+  - type: textarea
+    id: sub-issues
+    attributes:
+      label: Sub-issues
+      description: Link them as native GitHub sub-issues; mirror the list here.
+      placeholder: |
+        - [ ] #…
+        - [ ] #…
+    validations:
+      required: true
+  - type: textarea
+    id: done-when
+    attributes:
+      label: Done when
+      description: The condition for closing — typically "all sub-issues closed and integration verified."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature
+description: A new capability or enhancement that does not exist yet, shippable as one unit of value.
+type: Feature
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the problem to be solved or the gap addressed. Sketch the approach if known.
+      value: |
+        ## Problem / motivation
+        What need or gap this addresses.
+
+        ## Proposed solution
+        What to build. Sketch the approach if known.
+
+        ## Acceptance criteria
+        - [ ] Observable condition 1
+        - [ ] Observable condition 2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,36 @@
+name: Spike
+description: A timeboxed investigation whose deliverable is a decision, answer, or recommendation — not shipped code.
+type: Spike
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A **spike** answers a question whose outcome is genuinely uncertain; it produces a _conclusion_, not production code, and typically spawns follow-up issues. If the steps are already known, it's a **Task**. See the [issue-reporting standard](https://github.com/HeroicLands/sohl-kethira-basic/blob/main/.github/ISSUE_REPORTING.md).
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: The specific thing we need to decide or learn.
+    validations:
+      required: true
+  - type: input
+    id: timebox
+    attributes:
+      label: Timebox
+      description: e.g. 1 day / 4 hours. Required.
+    validations:
+      required: true
+  - type: textarea
+    id: deliverable
+    attributes:
+      label: Deliverable
+      description: The form of the answer — a decision, recommendation, written finding, or throwaway prototype. NOT production code.
+    validations:
+      required: true
+  - type: textarea
+    id: follow-up
+    attributes:
+      label: Follow-up
+      description: Note that follow-up feature/task/bug issues will be filed from the outcome.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,22 @@
+name: Task
+description: Necessary work that is neither a defect nor a new capability — a chore, refactor, tooling, docs, or release.
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A **task** is maintenance/chore work (a defect is a **Bug**; new capability is a **Feature**; exploratory work with an uncertain outcome is a **Spike**). A behavior-preserving refactor is a task tagged `tech-debt`. See the [issue-reporting standard](https://github.com/HeroicLands/sohl-kethira-basic/blob/main/.github/ISSUE_REPORTING.md).
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: The work to be done.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: The reason it's needed (keeps chores from looking arbitrary).
+    validations:
+      required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,59 @@
+# Authoritative label registry for the sohl-kethira-basic repository.
+#
+# This file is the machine-readable source of truth for §3 of
+# .github/ISSUE_REPORTING.md — the two are kept in sync by
+# `utils/check-labels.mjs` (run as `npm run lint:labels`). Editing the registry
+# means editing BOTH: this file (name/color/description) and the §3 table.
+#
+# GitHub's labels are reconciled to this file by `utils/sync-labels.mjs`, run by
+# .github/workflows/labels-sync.yml. The set is CLOSED: any label on GitHub that
+# is not listed here is deleted on sync. Do not invent labels — extending the
+# registry is a deliberate edit to this file and §3.
+#
+# The registry is deliberately the NARROWEST in the project: this repository
+# ships Foundry compendium packs and nothing else — no system code, no test
+# suite, and no site — so `system`, `tests`, and `site` are absent.
+
+- name: content
+  color: "58ec8d"
+  description: Kethira material — notes, compendium packs, actors, items, journals, scenes, artwork.
+
+- name: documentation
+  color: "0075ca"
+  description: Documentation about this repository — README, CLAUDE.md, process, authoring guides.
+
+- name: devops
+  color: "e07b31"
+  description: Build, tooling, pack pipeline, release, repo config.
+
+- name: security
+  color: "b60205"
+  description: "Attack surface: data integrity, script execution, injection, or private-disclosure risk."
+
+- name: tech-debt
+  color: "68691b"
+  description: Restructuring or cleanup of working content or tooling; refactors.
+
+- name: regression
+  color: "d93f0b"
+  description: Something that previously worked and stopped. Pairs with type bug.
+
+- name: breaking-change
+  color: "8d0f09"
+  description: Alters a shortcode, document ID, or pack compatibility in a way worlds will notice.
+
+- name: blocked
+  color: "c5702e"
+  description: Cannot proceed until an external dependency or another issue clears.
+
+- name: duplicate
+  color: "cfd3d7"
+  description: This issue or pull request already exists.
+
+- name: question
+  color: "0f5594"
+  description: Further information is requested.
+
+- name: wontfix
+  color: "ffffff"
+  description: This will not be worked on.

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,32 @@
+name: Sync labels
+
+# Reconcile the repository's GitHub labels to the authoritative registry in
+# .github/labels.yml (utils/sync-labels.mjs). Runs when the registry changes on
+# main, or on demand. The set is closed: labels not in the registry are deleted.
+
+on:
+  push:
+    branches: [main]
+    paths: [".github/labels.yml"]
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: labels-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: node utils/sync-labels.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/no-attribution.yml
+++ b/.github/workflows/no-attribution.yml
@@ -1,0 +1,62 @@
+name: No Attribution
+
+# Fail the check when a pull request's title, body, or any of its commit messages
+# carries AI/assistant attribution (a Co-Authored-By trailer naming an assistant,
+# or a "Generated with Claude Code"-style signature). This never edits anything —
+# it only reports and fails, so a human decides how to fix it. The commit-message
+# rule mirrors the local .githooks/commit-msg hook; keep the pattern in sync.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  no-attribution:
+    name: No AI attribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan PR title, body, and commit messages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Anchored to the start of a line: real attribution is a
+          # trailer / signature at column 0, so prose that merely mentions
+          # these phrases mid-sentence (e.g. this PR's own description)
+          # does not trip it. The generated-with branch tolerates a
+          # leading emoji/space.
+          pattern='^[[:space:]]*co-authored-by:.*(claude|anthropic)|^[^[:alpha:]]*generated with .*claude code'
+          fail=0
+
+          scan() {
+              name="$1"
+              text="$2"
+              hits="$(printf '%s' "$text" | grep -iEn "$pattern" || true)"
+              if [ -n "$hits" ]; then
+                  echo "::error::AI/assistant attribution found in $name"
+                  printf '%s\n' "$hits" | sed 's/^/    /'
+                  fail=1
+              fi
+          }
+
+          scan "PR title" "$PR_TITLE"
+          scan "PR body" "$PR_BODY"
+
+          messages="$(gh api "repos/$REPO/pulls/$NUMBER/commits" --paginate --jq '.[].commit.message')"
+          scan "commit messages" "$messages"
+
+          if [ "$fail" -ne 0 ]; then
+              echo "::error::Remove the attribution (e.g. 'Co-Authored-By: Claude …', 'Generated with Claude Code'). Edit the PR title/body, and amend/rebase any commit whose message carries it, then push."
+              exit 1
+          fi
+
+          echo "No AI attribution found."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to the Kethira content module
+
+This repository ships the `kethira` package: **unofficial Hârn fan material**
+under [Keléstia's Fan Material Guidelines](https://www.kelestia.com/faq#n86),
+licensed separately from Song of Heroic Lands and distributed as Foundry
+compendium packs.
+
+**It is a deliberate carve-out.** Nothing in the system repository or
+`sohl-thalorna` may depend on it, so it can be withdrawn without affecting
+either. Any change that would create such a dependency is out of scope — raise it
+before filing.
+
+## Filing an issue
+
+**This repository tracks its own work.** File Kethira issues here, not in the
+system repository — [§9 of the issue-reporting standard](.github/ISSUE_REPORTING.md#9-which-repository-does-an-issue-belong-in)
+says which repository a given piece of work belongs in.
+
+Every issue is classified on four axes — **type**, **priority**, **labels**, and
+**milestone**. The standard defines each one, and the issue forms pre-fill the
+body shape for the type you pick:
+
+- [Issue Reporting standard](.github/ISSUE_REPORTING.md)
+- [Open an issue](https://github.com/HeroicLands/sohl-kethira-basic/issues/new/choose)
+
+Exploitable weaknesses go to a **private advisory**, never a public issue — see
+[SECURITY.md](SECURITY.md). A **licence** breach is a public `bug`, not an
+advisory.
+
+## Making a change
+
+`main` is protected: it takes no direct pushes. Every change lands through a pull
+request.
+
+1. **Find or file the tracking issue.** Pure repo housekeeping (`chore/*`) may skip
+   this; anything else gets an issue first, so you have its number for the branch.
+2. **Branch off current `main`**, named `<type>/<issue_#>_<short-kebab-summary>` —
+   e.g. `feat/12_western-kingdoms`, `bug/19_dead-deity-link`. Issue-free
+   housekeeping is `chore/<slug>`.
+3. **Make the change**, keeping it small and focused — one feature, one fix, or one
+   documentation improvement per pull request.
+4. **Verify it.** `npm run lint` must pass, and `npm run build` must compile every
+   note into its pack.
+5. **Commit** in Conventional-Commits style, and **open a pull request** with
+   `Closes #<n>` and a what/why description.
+
+**No AI/assistant attribution** in commit messages, pull-request titles or bodies,
+or issues — no `Co-Authored-By:` trailer naming an assistant, and no "Generated
+with Claude Code"-style signature. A committed `commit-msg` hook (activated by
+`npm install`) rejects such commits locally, and the **No Attribution** GitHub
+Actions check fails any pull request carrying it.
+
+## Prohibited content
+
+Under no circumstances commit material that the Fan Material Guidelines do not
+cover: art, maps, or illustrations owned by Keléstia Productions or any third
+party; verbatim rulebook text or tables; or trade dress. Game mechanics may be
+implemented, but the specific creative expression used to describe them may not be
+reproduced. If you are unsure whether material is permissible, ask before
+contributing it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities privately via the "Report a vulnerability"
+button on this repo's Security tab (Security → Advisories). Please do not
+open a public issue for security problems — see
+[§7 of the issue-reporting standard](.github/ISSUE_REPORTING.md#7-security-issues--special-handling).
+
+I'll acknowledge the report, develop a fix in a private advisory, and credit
+you on publication if you'd like.
+
+## Supported versions
+
+The latest released version receives security fixes; older versions do not.
+
+## Scope
+
+This repository ships a Foundry VTT content module — compendium packs of
+journals, items, actors, and scenes. There is no application code, so the
+relevant concerns are content-borne: text rendered into other users' clients
+(item names and descriptions, journal bodies) and any macro shipped in a pack.
+
+A weakness in the SoHL system that this content merely exercises belongs in the
+[system repository's](https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/security/advisories/new)
+advisories, not here.
+
+**Licence problems are not security problems.** Third-party art or text shipped
+in a pack is a public `bug`, filed normally — not an advisory.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "HarnMaster Kethira Basic Items",
   "description": "Basic items needed for playing Song of Heroic Lands in the world of Kethira",
   "version": "0.5.3",
-  "bugs": "https://github.com/toastygm/sohl-kethira-basic/issues",
+  "bugs": "https://github.com/HeroicLands/sohl-kethira-basic/issues",
   "license": "LICENSE",
   "readme": "README.md",
   "authors": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.5.3",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@heroiclands/content-build": "^0.3.0"
+                "@heroiclands/content-build": "^0.3.0",
+                "yaml": "^2.9.0"
             },
             "engines": {
                 "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -11,21 +11,25 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/toastygm/sohl-kethira-basic.git"
+        "url": "git+https://github.com/HeroicLands/sohl-kethira-basic.git"
     },
     "bugs": {
-        "url": "https://github.com/toastygm/sohl-kethira-basic/issues"
+        "url": "https://github.com/HeroicLands/sohl-kethira-basic/issues"
     },
     "engines": {
         "node": ">=24.0.0"
     },
     "scripts": {
+        "prepare": "git config core.hooksPath .githooks || true",
         "build": "npm run build:compiledb",
         "build:compiledb": "content-build package compile",
         "build:unpackdb": "content-build package unpack",
-        "build:cleandb": "content-build package clean"
+        "build:cleandb": "content-build package clean",
+        "lint": "npm run lint:labels",
+        "lint:labels": "node utils/check-labels.mjs"
     },
     "devDependencies": {
-        "@heroiclands/content-build": "^0.3.0"
+        "@heroiclands/content-build": "^0.3.0",
+        "yaml": "^2.9.0"
     }
 }

--- a/utils/check-labels.mjs
+++ b/utils/check-labels.mjs
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the Kethira content module for the Song of Heroic Lands (SoHL) system.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.org>
+ *
+ * This build/tooling script is derived from the SoHL system repository and is
+ * licensed under the GNU General Public License v3.0 (GPLv3). It is NOT covered
+ * by this repository's LICENSE file, which governs the shipped Hârn fan material.
+ *
+ * For full terms, visit: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * CI guard: the label registry has two faces that MUST agree —
+ * `.github/labels.yml` (the machine source synced to GitHub) and the §3 table in
+ * `.github/ISSUE_REPORTING.md` (the documented reference). This asserts the set of
+ * label names is identical in both, so neither can drift or "invent" a label the
+ * other doesn't have.
+ *
+ * Usage: node utils/check-labels.mjs   (run as part of `npm run lint`)
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+/** GitHub caps a label description at 100 characters (API 422 beyond that). */
+const MAX_DESCRIPTION = 100;
+
+/** The documented face of the registry — its §3 table is the other source of truth. */
+const DOC = ".github/ISSUE_REPORTING.md";
+
+/**
+ * Label names declared in the machine registry. Also validates each entry's
+ * description length, so an over-long description fails `npm run lint` here
+ * rather than mid-sync against the GitHub API.
+ */
+function registryNames() {
+  const list = parse(readFileSync(resolve(".github/labels.yml"), "utf8"));
+  const tooLong = list.filter(
+    (l) => (l.description ?? "").length > MAX_DESCRIPTION,
+  );
+  if (tooLong.length) {
+    console.error(
+      `check-labels: label description exceeds ${MAX_DESCRIPTION} chars (GitHub's limit):`,
+    );
+    for (const l of tooLong) {
+      console.error(`  ${l.name} — ${l.description.length} chars`);
+    }
+    process.exit(1);
+  }
+  return new Set(list.map((l) => l.name));
+}
+
+/** Label names listed in the §3 table of the issue-reporting doc. */
+function docNames() {
+  const md = readFileSync(resolve(DOC), "utf8").split("\n");
+  const start = md.findIndex((l) => /^##\s+3\./.test(l));
+  if (start < 0) throw new Error(`Could not find §3 in ${DOC}`);
+  const end = md.findIndex((l, i) => i > start && /^##\s+\d/.test(l));
+  const section = md.slice(start, end < 0 ? md.length : end);
+  const names = new Set();
+  for (const line of section) {
+    // A registry row is a table row whose first cell is `` `label-name` ``.
+    const m = line.match(/^\|\s*`([a-z][a-z-]*)`\s*\|/);
+    if (m) names.add(m[1]);
+  }
+  return names;
+}
+
+function diff(a, b) {
+  return [...a].filter((x) => !b.has(x));
+}
+
+const registry = registryNames();
+const doc = docNames();
+
+const missingFromDoc = diff(registry, doc);
+const missingFromRegistry = diff(doc, registry);
+
+if (missingFromDoc.length || missingFromRegistry.length) {
+  console.error(`check-labels: .github/labels.yml and ${DOC} §3 disagree.`);
+  if (missingFromDoc.length)
+    console.error(`  in labels.yml but not §3: ${missingFromDoc.join(", ")}`);
+  if (missingFromRegistry.length)
+    console.error(
+      `  in §3 but not labels.yml: ${missingFromRegistry.join(", ")}`,
+    );
+  console.error(`Edit both when changing the registry (see ${DOC} §3).`);
+  process.exit(1);
+}
+
+console.log(`check-labels: registry and §3 agree (${registry.size} labels).`);

--- a/utils/sync-labels.mjs
+++ b/utils/sync-labels.mjs
@@ -1,0 +1,173 @@
+/*
+ * This file is part of the Kethira content module for the Song of Heroic Lands (SoHL) system.
+ * Copyright (c) 2024-2026 Tom Rodriguez ("Toasty") — <toasty@heroiclands.org>
+ *
+ * This build/tooling script is derived from the SoHL system repository and is
+ * licensed under the GNU General Public License v3.0 (GPLv3). It is NOT covered
+ * by this repository's LICENSE file, which governs the shipped Hârn fan material.
+ *
+ * For full terms, visit: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * Reconcile GitHub's repository labels to the authoritative registry in
+ * `.github/labels.yml`. The registry is a CLOSED set: labels present here are
+ * created or updated (color + description); labels on GitHub that are absent
+ * here are deleted. This is the "no invented labels" enforcement from
+ * .github/ISSUE_REPORTING.md §3.
+ *
+ * Usage:
+ *   node utils/sync-labels.mjs --dry-run     # print the plan, change nothing
+ *   node utils/sync-labels.mjs               # apply
+ *
+ * Auth/target come from the environment (as in GitHub Actions):
+ *   GITHUB_TOKEN / GH_TOKEN   a token with `issues: write` on the repo
+ *   GITHUB_REPOSITORY          "owner/repo" (falls back to `--repo owner/repo`)
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const repoArg = process.argv[process.argv.indexOf("--repo") + 1];
+const REPO =
+  (process.argv.includes("--repo") ? repoArg : null) ??
+  process.env.GITHUB_REPOSITORY;
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+if (!REPO) {
+  console.error(
+    "No repository — set GITHUB_REPOSITORY or pass --repo owner/repo.",
+  );
+  process.exit(1);
+}
+if (!TOKEN && !DRY_RUN) {
+  console.error("No token — set GITHUB_TOKEN (or run with --dry-run).");
+  process.exit(1);
+}
+
+const API = "https://api.github.com";
+const headers = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+};
+
+/** Read and validate the label registry. */
+function readRegistry() {
+  const file = resolve(".github/labels.yml");
+  const list = parse(readFileSync(file, "utf8"));
+  if (!Array.isArray(list)) {
+    throw new Error(".github/labels.yml must be a list of labels.");
+  }
+  const byName = new Map();
+  for (const entry of list) {
+    if (!entry?.name || !entry?.color) {
+      throw new Error(
+        `Each label needs a name and color: ${JSON.stringify(entry)}`,
+      );
+    }
+    byName.set(entry.name, {
+      name: entry.name,
+      color: String(entry.color).replace(/^#/, "").toLowerCase(),
+      description: entry.description ?? "",
+    });
+  }
+  return byName;
+}
+
+/** GET every label on the repository (paginated). */
+async function fetchCurrentLabels() {
+  const out = new Map();
+  for (let page = 1; ; page++) {
+    const res = await fetch(
+      `${API}/repos/${REPO}/labels?per_page=100&page=${page}`,
+      { headers },
+    );
+    if (!res.ok) {
+      throw new Error(`GET labels failed: ${res.status} ${await res.text()}`);
+    }
+    const batch = await res.json();
+    for (const l of batch) {
+      out.set(l.name, {
+        name: l.name,
+        color: String(l.color).toLowerCase(),
+        description: l.description ?? "",
+      });
+    }
+    if (batch.length < 100) break;
+  }
+  return out;
+}
+
+async function api(method, path, body) {
+  if (DRY_RUN) return;
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
+async function main() {
+  const want = readRegistry();
+  const have = await fetchCurrentLabels();
+
+  const creates = [];
+  const updates = [];
+  const deletes = [];
+
+  for (const label of want.values()) {
+    const cur = have.get(label.name);
+    if (!cur) creates.push(label);
+    else if (
+      cur.color !== label.color ||
+      (cur.description ?? "") !== label.description
+    ) {
+      updates.push(label);
+    }
+  }
+  for (const name of have.keys()) {
+    if (!want.has(name)) deletes.push(name);
+  }
+
+  const plan = `${creates.length} to create, ${updates.length} to update, ${deletes.length} to delete`;
+  console.log(`sync-labels (${REPO})${DRY_RUN ? " [dry-run]" : ""}: ${plan}`);
+  for (const l of creates) console.log(`  + create  ${l.name}`);
+  for (const l of updates) console.log(`  ~ update  ${l.name}`);
+  for (const n of deletes) console.log(`  - delete  ${n}`);
+
+  for (const l of creates) {
+    await api("POST", `/repos/${REPO}/labels`, {
+      name: l.name,
+      color: l.color,
+      description: l.description,
+    });
+  }
+  for (const l of updates) {
+    await api("PATCH", `/repos/${REPO}/labels/${encodeURIComponent(l.name)}`, {
+      color: l.color,
+      description: l.description,
+    });
+  }
+  for (const n of deletes) {
+    await api("DELETE", `/repos/${REPO}/labels/${encodeURIComponent(n)}`);
+  }
+
+  console.log(
+    DRY_RUN ? "✅ dry-run complete — no changes made." : "✅ labels synced.",
+  );
+}
+
+main().catch((err) => {
+  console.error(err.message ?? err);
+  process.exit(1);
+});


### PR DESCRIPTION
Stands this repository up as a first-class project with its own issue tracker and change process, rather than being governed informally from the system repository.

## What changed

- **Issue forms** for all five organization-level types — Bug, Feature, Epic, Task, Spike — plus a `config.yml` that disables blank issues, routes exploitable weaknesses to a private advisory, and sends system-code reports to the system repository.
- **A closed label registry** (`.github/labels.yml`, 11 labels) — the narrowest in the project. This repository ships compendium packs and nothing else, so `system`, `tests`, `site`, and `thalorna` are all absent.
- **The four-axis standard** — type, priority, labels, milestone — in `.github/ISSUE_REPORTING.md`, adapted for a content-only carve-out: a bug is a wrong or unloadable *fact* rather than a crash, a licence breach is a public `bug` rather than an advisory, and §9 records both which repository owns a piece of work and that nothing outside this one may depend on it.
- **`check-labels.mjs`** wired into a new `npm run lint`, so the registry and the §3 table cannot drift. Adds `yaml` as the only new dev dependency.
- **`CONTRIBUTING.md` and `SECURITY.md`**, neither of which existed here.
- **The no-attribution guards**: the `commit-msg` hook (activated by a new `prepare` script) and the `No Attribution` workflow.
- **Corrects the `bugs` and `repository` URLs** in `package.json` and `module.json`, which still named the pre-transfer `toastygm/` owner and so pointed readers at the wrong issue tracker.

## Why

This is a licence carve-out — unofficial Hârn fan material under Keléstia's Fan Material Guidelines, which must stay withdrawable without affecting the system or any other package. Tracking its work in the system repository's backlog worked against that: it entangled this module's dependency chain with the system's, and made the boundary that keeps the carve-out removable harder to see and to police. An independent tracker states the boundary plainly and gives licence-compliance work a place of its own.

## Already applied outside this diff

- Labels on GitHub are synced to the new registry. The five GitHub defaults (`bug`, `enhancement`, `good first issue`, `help wanted`, `invalid`) were deleted; the repository had no issues carrying them.
- The dormant `main` ruleset is **enabled and updated** to match the system repository's: no direct pushes, no deletion, no force-push, pull request with one approving review, `OrganizationAdmin` bypass. It previously existed but was disabled, with no bypass actor.

## Not changed

The `manifest` and `download` URLs in `module.json` still name `toastygm/`. Those are the live update path for installed modules and GitHub redirects them, so moving them is a release-infrastructure decision, not part of this one.

## Verification

- `npm run lint` — registry and §3 agree (11 labels)
- `npm run build` — 269 items compiled, all packs written
- All six issue forms and both workflows parse as YAML
- Type/priority/label round-trip confirmed on #9 (type=Task, priority=Medium, labels=devops+documentation)

**Note:** the issue forms only take effect once this is on `main`.

Closes #9
