### PR TITLE
fix(content): land the sunsign active effects in the compiled pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HârnMaster Kethira Module for Song of Heroic Lands
-[![Version (latest)](https://img.shields.io/github/v/release/toastygm/sohl-kethira-basic)](https://github.com/toastygm/sohl-kethira-basic/releases/latest)
+[![Version (latest)](https://img.shields.io/github/v/release/HeroicLands/sohl-kethira-basic)](https://github.com/HeroicLands/sohl-kethira-basic/releases/latest)
 [![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fsohl-kethira-basic&colorB=4aa94a)](https://forge-vtt.com/bazaar#package=sohl-kethira-basic)
-[![GitHub downloads (latest)](https://img.shields.io/badge/dynamic/json?label=Downloads@latest&query=assets[?(@.name.includes('zip'))].download_count&url=https://api.github.com/repos/toastygm/sohl-kethira-basic/releases/latest&color=green)](https://github.com/toastygm/sohl-kethira-basic/releases/latest)
+[![GitHub downloads (latest)](https://img.shields.io/badge/dynamic/json?label=Downloads@latest&query=assets[?(@.name.includes('zip'))].download_count&url=https://api.github.com/repos/HeroicLands/sohl-kethira-basic/releases/latest&color=green)](https://github.com/HeroicLands/sohl-kethira-basic/releases/latest)
 
 This module provides the necessary items, actors, and assets needed to play in the
 HârnWorld setting for HârnMaster Kethira.

--- a/assets/content/Mysteries/Sunsigns/Ahnu-Angberelius.md
+++ b/assets/content/Mysteries/Sunsigns/Ahnu-Angberelius.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Áhnù-Angberélius — Metal skills (+10 EML)"
-          type: sohleffectdata
-          _id: F2YBGfyfhHNWWMYw
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+effects:
+    - name: "Áhnù-Angberélius — Metal skills (+10 EML)"
+      type: sohleffectdata
+      _id: F2YBGfyfhHNWWMYw
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!Lk9xrTRAj6O4oNNd.F2YBGfyfhHNWWMYw"
-        - name: "Áhnù-Angberélius — Fire skills (+15 EML)"
-          type: sohleffectdata
-          _id: GWwJUhzCLg3RQaNm
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!Lk9xrTRAj6O4oNNd.F2YBGfyfhHNWWMYw"
+    - name: "Áhnù-Angberélius — Fire skills (+15 EML)"
+      type: sohleffectdata
+      _id: GWwJUhzCLg3RQaNm
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!Lk9xrTRAj6O4oNNd.GWwJUhzCLg3RQaNm"
-        - name: "Áhnù-Angberélius — Air skills (+5 EML)"
-          type: sohleffectdata
-          _id: EzNNUPfhW3X510Ph
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!Lk9xrTRAj6O4oNNd.GWwJUhzCLg3RQaNm"
+    - name: "Áhnù-Angberélius — Air skills (+5 EML)"
+      type: sohleffectdata
+      _id: EzNNUPfhW3X510Ph
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!Lk9xrTRAj6O4oNNd.EzNNUPfhW3X510Ph"
-        - name: "Áhnù-Angberélius — Spirit skills (-5 EML)"
-          type: sohleffectdata
-          _id: 5NE33qC0F8A5OxE6
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!Lk9xrTRAj6O4oNNd.EzNNUPfhW3X510Ph"
+    - name: "Áhnù-Angberélius — Spirit skills (-5 EML)"
+      type: sohleffectdata
+      _id: 5NE33qC0F8A5OxE6
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!Lk9xrTRAj6O4oNNd.5NE33qC0F8A5OxE6"
-        - name: "Áhnù-Angberélius — Water skills (-10 EML)"
-          type: sohleffectdata
-          _id: c6643q2LKPinxQH7
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!Lk9xrTRAj6O4oNNd.5NE33qC0F8A5OxE6"
+    - name: "Áhnù-Angberélius — Water skills (-10 EML)"
+      type: sohleffectdata
+      _id: c6643q2LKPinxQH7
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!Lk9xrTRAj6O4oNNd.c6643q2LKPinxQH7"
+      _key: "!items.effects!Lk9xrTRAj6O4oNNd.c6643q2LKPinxQH7"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Ahnu.md
+++ b/assets/content/Mysteries/Sunsigns/Ahnu.md
@@ -23,55 +23,55 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Áhnù — Metal skills (+10 EML)"
-          type: sohleffectdata
-          _id: 3fqNLpu8CoMGPcDa
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+effects:
+    - name: "Áhnù — Metal skills (+10 EML)"
+      type: sohleffectdata
+      _id: 3fqNLpu8CoMGPcDa
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!hKLc4IN1kA86hA15.3fqNLpu8CoMGPcDa"
-        - name: "Áhnù — Fire skills (+10 EML)"
-          type: sohleffectdata
-          _id: rvjgQONaOUJutb6q
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!hKLc4IN1kA86hA15.3fqNLpu8CoMGPcDa"
+    - name: "Áhnù — Fire skills (+10 EML)"
+      type: sohleffectdata
+      _id: rvjgQONaOUJutb6q
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!hKLc4IN1kA86hA15.rvjgQONaOUJutb6q"
-        - name: "Áhnù — Spirit skills (-10 EML)"
-          type: sohleffectdata
-          _id: AOM3Um9NM7UUBfps
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!hKLc4IN1kA86hA15.rvjgQONaOUJutb6q"
+    - name: "Áhnù — Spirit skills (-10 EML)"
+      type: sohleffectdata
+      _id: AOM3Um9NM7UUBfps
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!hKLc4IN1kA86hA15.AOM3Um9NM7UUBfps"
-        - name: "Áhnù — Water skills (-10 EML)"
-          type: sohleffectdata
-          _id: PCqLkTt8J1rCeYjh
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!hKLc4IN1kA86hA15.AOM3Um9NM7UUBfps"
+    - name: "Áhnù — Water skills (-10 EML)"
+      type: sohleffectdata
+      _id: PCqLkTt8J1rCeYjh
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!hKLc4IN1kA86hA15.PCqLkTt8J1rCeYjh"
+      _key: "!items.effects!hKLc4IN1kA86hA15.PCqLkTt8J1rCeYjh"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Angberelius-Nadai.md
+++ b/assets/content/Mysteries/Sunsigns/Angberelius-Nadai.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Angberélius-Nadái — Earth skills (-5 EML)"
-          type: sohleffectdata
-          _id: w4Yb3smNvdPc1NLV
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Angberélius-Nadái — Earth skills (-5 EML)"
+      type: sohleffectdata
+      _id: w4Yb3smNvdPc1NLV
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!TdjxTKZFnadjcNx8.w4Yb3smNvdPc1NLV"
-        - name: "Angberélius-Nadái — Metal skills (+5 EML)"
-          type: sohleffectdata
-          _id: RzENtxl7yrRj1tu8
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!TdjxTKZFnadjcNx8.w4Yb3smNvdPc1NLV"
+    - name: "Angberélius-Nadái — Metal skills (+5 EML)"
+      type: sohleffectdata
+      _id: RzENtxl7yrRj1tu8
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!TdjxTKZFnadjcNx8.RzENtxl7yrRj1tu8"
-        - name: "Angberélius-Nadái — Fire skills (+15 EML)"
-          type: sohleffectdata
-          _id: 2BDdvvVQMOtH9u36
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!TdjxTKZFnadjcNx8.RzENtxl7yrRj1tu8"
+    - name: "Angberélius-Nadái — Fire skills (+15 EML)"
+      type: sohleffectdata
+      _id: 2BDdvvVQMOtH9u36
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!TdjxTKZFnadjcNx8.2BDdvvVQMOtH9u36"
-        - name: "Angberélius-Nadái — Air skills (+10 EML)"
-          type: sohleffectdata
-          _id: YMfwmukGVawpoQmB
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!TdjxTKZFnadjcNx8.2BDdvvVQMOtH9u36"
+    - name: "Angberélius-Nadái — Air skills (+10 EML)"
+      type: sohleffectdata
+      _id: YMfwmukGVawpoQmB
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!TdjxTKZFnadjcNx8.YMfwmukGVawpoQmB"
-        - name: "Angberélius-Nadái — Water skills (-10 EML)"
-          type: sohleffectdata
-          _id: t7dpHNcD33fH4Hle
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!TdjxTKZFnadjcNx8.YMfwmukGVawpoQmB"
+    - name: "Angberélius-Nadái — Water skills (-10 EML)"
+      type: sohleffectdata
+      _id: t7dpHNcD33fH4Hle
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!TdjxTKZFnadjcNx8.t7dpHNcD33fH4Hle"
+      _key: "!items.effects!TdjxTKZFnadjcNx8.t7dpHNcD33fH4Hle"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Angberelius.md
+++ b/assets/content/Mysteries/Sunsigns/Angberelius.md
@@ -23,79 +23,79 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Angberélius — Earth skills (-5 EML)"
-          type: sohleffectdata
-          _id: MX2WgQWzyQUydsSe
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Angberélius — Earth skills (-5 EML)"
+      type: sohleffectdata
+      _id: MX2WgQWzyQUydsSe
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!hSyl2FBaJd2z4cBw.MX2WgQWzyQUydsSe"
-        - name: "Angberélius — Metal skills (+5 EML)"
-          type: sohleffectdata
-          _id: dZstIFrn0JbKtV6u
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!hSyl2FBaJd2z4cBw.MX2WgQWzyQUydsSe"
+    - name: "Angberélius — Metal skills (+5 EML)"
+      type: sohleffectdata
+      _id: dZstIFrn0JbKtV6u
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!hSyl2FBaJd2z4cBw.dZstIFrn0JbKtV6u"
-        - name: "Angberélius — Fire skills (+15 EML)"
-          type: sohleffectdata
-          _id: e8VXKwknxu5Hq39U
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!hSyl2FBaJd2z4cBw.dZstIFrn0JbKtV6u"
+    - name: "Angberélius — Fire skills (+15 EML)"
+      type: sohleffectdata
+      _id: e8VXKwknxu5Hq39U
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!hSyl2FBaJd2z4cBw.e8VXKwknxu5Hq39U"
-        - name: "Angberélius — Air skills (+5 EML)"
-          type: sohleffectdata
-          _id: XHD62llSJ4CsUN2w
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!hSyl2FBaJd2z4cBw.e8VXKwknxu5Hq39U"
+    - name: "Angberélius — Air skills (+5 EML)"
+      type: sohleffectdata
+      _id: XHD62llSJ4CsUN2w
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!hSyl2FBaJd2z4cBw.XHD62llSJ4CsUN2w"
-        - name: "Angberélius — Spirit skills (-5 EML)"
-          type: sohleffectdata
-          _id: 2CPOFU7nTyKyB1es
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!hSyl2FBaJd2z4cBw.XHD62llSJ4CsUN2w"
+    - name: "Angberélius — Spirit skills (-5 EML)"
+      type: sohleffectdata
+      _id: 2CPOFU7nTyKyB1es
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!hSyl2FBaJd2z4cBw.2CPOFU7nTyKyB1es"
-        - name: "Angberélius — Water skills (-15 EML)"
-          type: sohleffectdata
-          _id: jTIgz4TotiDyirAY
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!hSyl2FBaJd2z4cBw.2CPOFU7nTyKyB1es"
+    - name: "Angberélius — Water skills (-15 EML)"
+      type: sohleffectdata
+      _id: jTIgz4TotiDyirAY
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-15"
                 priority: null
-          _key: "!items.effects!hSyl2FBaJd2z4cBw.jTIgz4TotiDyirAY"
+      _key: "!items.effects!hSyl2FBaJd2z4cBw.jTIgz4TotiDyirAY"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Aralius-Feneri.md
+++ b/assets/content/Mysteries/Sunsigns/Aralius-Feneri.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Arálius-Fenéri — Earth skills (+10 EML)"
-          type: sohleffectdata
-          _id: 2w9wucqdiloUI8iY
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Arálius-Fenéri — Earth skills (+10 EML)"
+      type: sohleffectdata
+      _id: 2w9wucqdiloUI8iY
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!TBfKIrDH7Oj8axKT.2w9wucqdiloUI8iY"
-        - name: "Arálius-Fenéri — Metal skills (+15 EML)"
-          type: sohleffectdata
-          _id: Api6E3euExc7hdnf
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!TBfKIrDH7Oj8axKT.2w9wucqdiloUI8iY"
+    - name: "Arálius-Fenéri — Metal skills (+15 EML)"
+      type: sohleffectdata
+      _id: Api6E3euExc7hdnf
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!TBfKIrDH7Oj8axKT.Api6E3euExc7hdnf"
-        - name: "Arálius-Fenéri — Fire skills (+5 EML)"
-          type: sohleffectdata
-          _id: W5pHOmwowX4KDVF4
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!TBfKIrDH7Oj8axKT.Api6E3euExc7hdnf"
+    - name: "Arálius-Fenéri — Fire skills (+5 EML)"
+      type: sohleffectdata
+      _id: W5pHOmwowX4KDVF4
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!TBfKIrDH7Oj8axKT.W5pHOmwowX4KDVF4"
-        - name: "Arálius-Fenéri — Air skills (-5 EML)"
-          type: sohleffectdata
-          _id: CmvBgYo7cz6udJVB
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!TBfKIrDH7Oj8axKT.W5pHOmwowX4KDVF4"
+    - name: "Arálius-Fenéri — Air skills (-5 EML)"
+      type: sohleffectdata
+      _id: CmvBgYo7cz6udJVB
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!TBfKIrDH7Oj8axKT.CmvBgYo7cz6udJVB"
-        - name: "Arálius-Fenéri — Spirit skills (-10 EML)"
-          type: sohleffectdata
-          _id: JwqLZZd3HMLMumQB
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!TBfKIrDH7Oj8axKT.CmvBgYo7cz6udJVB"
+    - name: "Arálius-Fenéri — Spirit skills (-10 EML)"
+      type: sohleffectdata
+      _id: JwqLZZd3HMLMumQB
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!TBfKIrDH7Oj8axKT.JwqLZZd3HMLMumQB"
+      _key: "!items.effects!TBfKIrDH7Oj8axKT.JwqLZZd3HMLMumQB"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Aralius.md
+++ b/assets/content/Mysteries/Sunsigns/Aralius.md
@@ -23,55 +23,55 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Arálius — Earth skills (+10 EML)"
-          type: sohleffectdata
-          _id: YwsZFl7EnqOs9wBk
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Arálius — Earth skills (+10 EML)"
+      type: sohleffectdata
+      _id: YwsZFl7EnqOs9wBk
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!ob9DL9Qd3GZOaXIE.YwsZFl7EnqOs9wBk"
-        - name: "Arálius — Metal skills (+10 EML)"
-          type: sohleffectdata
-          _id: Nfj4MXD2dvbco58U
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!ob9DL9Qd3GZOaXIE.YwsZFl7EnqOs9wBk"
+    - name: "Arálius — Metal skills (+10 EML)"
+      type: sohleffectdata
+      _id: Nfj4MXD2dvbco58U
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!ob9DL9Qd3GZOaXIE.Nfj4MXD2dvbco58U"
-        - name: "Arálius — Air skills (-10 EML)"
-          type: sohleffectdata
-          _id: NnUMAPuyZIEmidBP
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!ob9DL9Qd3GZOaXIE.Nfj4MXD2dvbco58U"
+    - name: "Arálius — Air skills (-10 EML)"
+      type: sohleffectdata
+      _id: NnUMAPuyZIEmidBP
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!ob9DL9Qd3GZOaXIE.NnUMAPuyZIEmidBP"
-        - name: "Arálius — Spirit skills (-10 EML)"
-          type: sohleffectdata
-          _id: Pj5GTveJbztiUcLo
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!ob9DL9Qd3GZOaXIE.NnUMAPuyZIEmidBP"
+    - name: "Arálius — Spirit skills (-10 EML)"
+      type: sohleffectdata
+      _id: Pj5GTveJbztiUcLo
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!ob9DL9Qd3GZOaXIE.Pj5GTveJbztiUcLo"
+      _key: "!items.effects!ob9DL9Qd3GZOaXIE.Pj5GTveJbztiUcLo"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Feneri-Ahnu.md
+++ b/assets/content/Mysteries/Sunsigns/Feneri-Ahnu.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Fenéri-Áhnù — Earth skills (+5 EML)"
-          type: sohleffectdata
-          _id: fLSGR0auRCz1zqT1
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Fenéri-Áhnù — Earth skills (+5 EML)"
+      type: sohleffectdata
+      _id: fLSGR0auRCz1zqT1
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!HBe2jEz45xImY3X6.fLSGR0auRCz1zqT1"
-        - name: "Fenéri-Áhnù — Metal skills (+15 EML)"
-          type: sohleffectdata
-          _id: BM8RO2Fa1vG37yVX
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!HBe2jEz45xImY3X6.fLSGR0auRCz1zqT1"
+    - name: "Fenéri-Áhnù — Metal skills (+15 EML)"
+      type: sohleffectdata
+      _id: BM8RO2Fa1vG37yVX
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!HBe2jEz45xImY3X6.BM8RO2Fa1vG37yVX"
-        - name: "Fenéri-Áhnù — Fire skills (+10 EML)"
-          type: sohleffectdata
-          _id: SYBlCcbmStSkOTzh
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!HBe2jEz45xImY3X6.BM8RO2Fa1vG37yVX"
+    - name: "Fenéri-Áhnù — Fire skills (+10 EML)"
+      type: sohleffectdata
+      _id: SYBlCcbmStSkOTzh
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!HBe2jEz45xImY3X6.SYBlCcbmStSkOTzh"
-        - name: "Fenéri-Áhnù — Spirit skills (-10 EML)"
-          type: sohleffectdata
-          _id: hDUvjVR2xjwfd3mR
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!HBe2jEz45xImY3X6.SYBlCcbmStSkOTzh"
+    - name: "Fenéri-Áhnù — Spirit skills (-10 EML)"
+      type: sohleffectdata
+      _id: hDUvjVR2xjwfd3mR
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!HBe2jEz45xImY3X6.hDUvjVR2xjwfd3mR"
-        - name: "Fenéri-Áhnù — Water skills (-5 EML)"
-          type: sohleffectdata
-          _id: 60vLbVJHxClh9mvb
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!HBe2jEz45xImY3X6.hDUvjVR2xjwfd3mR"
+    - name: "Fenéri-Áhnù — Water skills (-5 EML)"
+      type: sohleffectdata
+      _id: 60vLbVJHxClh9mvb
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!HBe2jEz45xImY3X6.60vLbVJHxClh9mvb"
+      _key: "!items.effects!HBe2jEz45xImY3X6.60vLbVJHxClh9mvb"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Feneri.md
+++ b/assets/content/Mysteries/Sunsigns/Feneri.md
@@ -23,79 +23,79 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Fenéri — Earth skills (+5 EML)"
-          type: sohleffectdata
-          _id: 7ORDngU1Mbnkz1Q5
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Fenéri — Earth skills (+5 EML)"
+      type: sohleffectdata
+      _id: 7ORDngU1Mbnkz1Q5
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!0rUilHMn9WsYi9Hn.7ORDngU1Mbnkz1Q5"
-        - name: "Fenéri — Metal skills (+15 EML)"
-          type: sohleffectdata
-          _id: jEzWqc7eWDZuef9D
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!0rUilHMn9WsYi9Hn.7ORDngU1Mbnkz1Q5"
+    - name: "Fenéri — Metal skills (+15 EML)"
+      type: sohleffectdata
+      _id: jEzWqc7eWDZuef9D
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!0rUilHMn9WsYi9Hn.jEzWqc7eWDZuef9D"
-        - name: "Fenéri — Fire skills (+5 EML)"
-          type: sohleffectdata
-          _id: PdZ2HrBgdAhoHMUQ
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!0rUilHMn9WsYi9Hn.jEzWqc7eWDZuef9D"
+    - name: "Fenéri — Fire skills (+5 EML)"
+      type: sohleffectdata
+      _id: PdZ2HrBgdAhoHMUQ
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!0rUilHMn9WsYi9Hn.PdZ2HrBgdAhoHMUQ"
-        - name: "Fenéri — Air skills (-5 EML)"
-          type: sohleffectdata
-          _id: ZqALvy6KrDCysNA1
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!0rUilHMn9WsYi9Hn.PdZ2HrBgdAhoHMUQ"
+    - name: "Fenéri — Air skills (-5 EML)"
+      type: sohleffectdata
+      _id: ZqALvy6KrDCysNA1
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!0rUilHMn9WsYi9Hn.ZqALvy6KrDCysNA1"
-        - name: "Fenéri — Spirit skills (-15 EML)"
-          type: sohleffectdata
-          _id: qdZfVA8Q63udndt3
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!0rUilHMn9WsYi9Hn.ZqALvy6KrDCysNA1"
+    - name: "Fenéri — Spirit skills (-15 EML)"
+      type: sohleffectdata
+      _id: qdZfVA8Q63udndt3
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-15"
                 priority: null
-          _key: "!items.effects!0rUilHMn9WsYi9Hn.qdZfVA8Q63udndt3"
-        - name: "Fenéri — Water skills (-5 EML)"
-          type: sohleffectdata
-          _id: qd9wm0vCmxctfsyh
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!0rUilHMn9WsYi9Hn.qdZfVA8Q63udndt3"
+    - name: "Fenéri — Water skills (-5 EML)"
+      type: sohleffectdata
+      _id: qd9wm0vCmxctfsyh
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!0rUilHMn9WsYi9Hn.qd9wm0vCmxctfsyh"
+      _key: "!items.effects!0rUilHMn9WsYi9Hn.qd9wm0vCmxctfsyh"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Hirin-Tarael.md
+++ b/assets/content/Mysteries/Sunsigns/Hirin-Tarael.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Hîrin-Táræl — Earth skills (-10 EML)"
-          type: sohleffectdata
-          _id: 2G698QRooJfNXKVq
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Hîrin-Táræl — Earth skills (-10 EML)"
+      type: sohleffectdata
+      _id: 2G698QRooJfNXKVq
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!5NYNbAPWe43ymyKZ.2G698QRooJfNXKVq"
-        - name: "Hîrin-Táræl — Metal skills (-5 EML)"
-          type: sohleffectdata
-          _id: xiqLYi8AwouI52ZT
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!5NYNbAPWe43ymyKZ.2G698QRooJfNXKVq"
+    - name: "Hîrin-Táræl — Metal skills (-5 EML)"
+      type: sohleffectdata
+      _id: xiqLYi8AwouI52ZT
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!5NYNbAPWe43ymyKZ.xiqLYi8AwouI52ZT"
-        - name: "Hîrin-Táræl — Fire skills (+5 EML)"
-          type: sohleffectdata
-          _id: zV7GjvIzPFOOZpiS
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!5NYNbAPWe43ymyKZ.xiqLYi8AwouI52ZT"
+    - name: "Hîrin-Táræl — Fire skills (+5 EML)"
+      type: sohleffectdata
+      _id: zV7GjvIzPFOOZpiS
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!5NYNbAPWe43ymyKZ.zV7GjvIzPFOOZpiS"
-        - name: "Hîrin-Táræl — Air skills (+15 EML)"
-          type: sohleffectdata
-          _id: EdTpW0InHZro5dcT
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!5NYNbAPWe43ymyKZ.zV7GjvIzPFOOZpiS"
+    - name: "Hîrin-Táræl — Air skills (+15 EML)"
+      type: sohleffectdata
+      _id: EdTpW0InHZro5dcT
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!5NYNbAPWe43ymyKZ.EdTpW0InHZro5dcT"
-        - name: "Hîrin-Táræl — Spirit skills (+10 EML)"
-          type: sohleffectdata
-          _id: 9TBgMoReVPXwJ82m
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!5NYNbAPWe43ymyKZ.EdTpW0InHZro5dcT"
+    - name: "Hîrin-Táræl — Spirit skills (+10 EML)"
+      type: sohleffectdata
+      _id: 9TBgMoReVPXwJ82m
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!5NYNbAPWe43ymyKZ.9TBgMoReVPXwJ82m"
+      _key: "!items.effects!5NYNbAPWe43ymyKZ.9TBgMoReVPXwJ82m"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Hirin.md
+++ b/assets/content/Mysteries/Sunsigns/Hirin.md
@@ -23,79 +23,79 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Hîrin — Earth skills (-15 EML)"
-          type: sohleffectdata
-          _id: wH0HeTgTxaqj1f6M
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Hîrin — Earth skills (-15 EML)"
+      type: sohleffectdata
+      _id: wH0HeTgTxaqj1f6M
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-15"
                 priority: null
-          _key: "!items.effects!EeL7L3sh2RMj63fO.wH0HeTgTxaqj1f6M"
-        - name: "Hîrin — Metal skills (-5 EML)"
-          type: sohleffectdata
-          _id: c0UNDwZZ4XVqO68f
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!EeL7L3sh2RMj63fO.wH0HeTgTxaqj1f6M"
+    - name: "Hîrin — Metal skills (-5 EML)"
+      type: sohleffectdata
+      _id: c0UNDwZZ4XVqO68f
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!EeL7L3sh2RMj63fO.c0UNDwZZ4XVqO68f"
-        - name: "Hîrin — Fire skills (+5 EML)"
-          type: sohleffectdata
-          _id: NS1Rx7ZE4gza1Nr9
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!EeL7L3sh2RMj63fO.c0UNDwZZ4XVqO68f"
+    - name: "Hîrin — Fire skills (+5 EML)"
+      type: sohleffectdata
+      _id: NS1Rx7ZE4gza1Nr9
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!EeL7L3sh2RMj63fO.NS1Rx7ZE4gza1Nr9"
-        - name: "Hîrin — Air skills (+15 EML)"
-          type: sohleffectdata
-          _id: zEa3uRKJSz0Eni8Q
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!EeL7L3sh2RMj63fO.NS1Rx7ZE4gza1Nr9"
+    - name: "Hîrin — Air skills (+15 EML)"
+      type: sohleffectdata
+      _id: zEa3uRKJSz0Eni8Q
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!EeL7L3sh2RMj63fO.zEa3uRKJSz0Eni8Q"
-        - name: "Hîrin — Spirit skills (+5 EML)"
-          type: sohleffectdata
-          _id: vx0wgxrx3SFuGNdO
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!EeL7L3sh2RMj63fO.zEa3uRKJSz0Eni8Q"
+    - name: "Hîrin — Spirit skills (+5 EML)"
+      type: sohleffectdata
+      _id: vx0wgxrx3SFuGNdO
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!EeL7L3sh2RMj63fO.vx0wgxrx3SFuGNdO"
-        - name: "Hîrin — Water skills (-5 EML)"
-          type: sohleffectdata
-          _id: c2MQvrWSx4loy3NK
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!EeL7L3sh2RMj63fO.vx0wgxrx3SFuGNdO"
+    - name: "Hîrin — Water skills (-5 EML)"
+      type: sohleffectdata
+      _id: c2MQvrWSx4loy3NK
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!EeL7L3sh2RMj63fO.c2MQvrWSx4loy3NK"
+      _key: "!items.effects!EeL7L3sh2RMj63fO.c2MQvrWSx4loy3NK"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Lado-Ulandus.md
+++ b/assets/content/Mysteries/Sunsigns/Lado-Ulandus.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Ládo-Ùlándus — Earth skills (+15 EML)"
-          type: sohleffectdata
-          _id: Lg9NBNn1lpDQ4D9y
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Ládo-Ùlándus — Earth skills (+15 EML)"
+      type: sohleffectdata
+      _id: Lg9NBNn1lpDQ4D9y
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!lXWpXFfh9Dbw3vJt.Lg9NBNn1lpDQ4D9y"
-        - name: "Ládo-Ùlándus — Metal skills (+5 EML)"
-          type: sohleffectdata
-          _id: Lfd9N5RuOUyRKaGM
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!lXWpXFfh9Dbw3vJt.Lg9NBNn1lpDQ4D9y"
+    - name: "Ládo-Ùlándus — Metal skills (+5 EML)"
+      type: sohleffectdata
+      _id: Lfd9N5RuOUyRKaGM
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!lXWpXFfh9Dbw3vJt.Lfd9N5RuOUyRKaGM"
-        - name: "Ládo-Ùlándus — Fire skills (-5 EML)"
-          type: sohleffectdata
-          _id: 9JJy1KFwh4yU6WbF
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!lXWpXFfh9Dbw3vJt.Lfd9N5RuOUyRKaGM"
+    - name: "Ládo-Ùlándus — Fire skills (-5 EML)"
+      type: sohleffectdata
+      _id: 9JJy1KFwh4yU6WbF
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!lXWpXFfh9Dbw3vJt.9JJy1KFwh4yU6WbF"
-        - name: "Ládo-Ùlándus — Air skills (-10 EML)"
-          type: sohleffectdata
-          _id: Blp4Ves0YMh3AnvB
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!lXWpXFfh9Dbw3vJt.9JJy1KFwh4yU6WbF"
+    - name: "Ládo-Ùlándus — Air skills (-10 EML)"
+      type: sohleffectdata
+      _id: Blp4Ves0YMh3AnvB
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!lXWpXFfh9Dbw3vJt.Blp4Ves0YMh3AnvB"
-        - name: "Ládo-Ùlándus — Water skills (+10 EML)"
-          type: sohleffectdata
-          _id: CgOp2KzvXK01KMjh
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!lXWpXFfh9Dbw3vJt.Blp4Ves0YMh3AnvB"
+    - name: "Ládo-Ùlándus — Water skills (+10 EML)"
+      type: sohleffectdata
+      _id: CgOp2KzvXK01KMjh
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!lXWpXFfh9Dbw3vJt.CgOp2KzvXK01KMjh"
+      _key: "!items.effects!lXWpXFfh9Dbw3vJt.CgOp2KzvXK01KMjh"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Lado.md
+++ b/assets/content/Mysteries/Sunsigns/Lado.md
@@ -23,55 +23,55 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Ládo — Earth skills (+10 EML)"
-          type: sohleffectdata
-          _id: KhpHvASKFQBTiwfT
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Ládo — Earth skills (+10 EML)"
+      type: sohleffectdata
+      _id: KhpHvASKFQBTiwfT
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!c6TTc2Ax2tjiyWcV.KhpHvASKFQBTiwfT"
-        - name: "Ládo — Fire skills (-10 EML)"
-          type: sohleffectdata
-          _id: XmbovcYYqz1j4QFE
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!c6TTc2Ax2tjiyWcV.KhpHvASKFQBTiwfT"
+    - name: "Ládo — Fire skills (-10 EML)"
+      type: sohleffectdata
+      _id: XmbovcYYqz1j4QFE
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!c6TTc2Ax2tjiyWcV.XmbovcYYqz1j4QFE"
-        - name: "Ládo — Air skills (-10 EML)"
-          type: sohleffectdata
-          _id: 9VnXeMp2vgAwSQen
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!c6TTc2Ax2tjiyWcV.XmbovcYYqz1j4QFE"
+    - name: "Ládo — Air skills (-10 EML)"
+      type: sohleffectdata
+      _id: 9VnXeMp2vgAwSQen
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!c6TTc2Ax2tjiyWcV.9VnXeMp2vgAwSQen"
-        - name: "Ládo — Water skills (+10 EML)"
-          type: sohleffectdata
-          _id: XruQ1Khz9nvYLiB6
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!c6TTc2Ax2tjiyWcV.9VnXeMp2vgAwSQen"
+    - name: "Ládo — Water skills (+10 EML)"
+      type: sohleffectdata
+      _id: XruQ1Khz9nvYLiB6
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!c6TTc2Ax2tjiyWcV.XruQ1Khz9nvYLiB6"
+      _key: "!items.effects!c6TTc2Ax2tjiyWcV.XruQ1Khz9nvYLiB6"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Masara-Lado.md
+++ b/assets/content/Mysteries/Sunsigns/Masara-Lado.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Masâra-Ládo — Earth skills (+10 EML)"
-          type: sohleffectdata
-          _id: ytB1HGmOKJZbfdVC
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Masâra-Ládo — Earth skills (+10 EML)"
+      type: sohleffectdata
+      _id: ytB1HGmOKJZbfdVC
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!IxhlQpnsJvoz4FK5.ytB1HGmOKJZbfdVC"
-        - name: "Masâra-Ládo — Fire skills (-10 EML)"
-          type: sohleffectdata
-          _id: Gp8ELCwrc7W2a85S
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!IxhlQpnsJvoz4FK5.ytB1HGmOKJZbfdVC"
+    - name: "Masâra-Ládo — Fire skills (-10 EML)"
+      type: sohleffectdata
+      _id: Gp8ELCwrc7W2a85S
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!IxhlQpnsJvoz4FK5.Gp8ELCwrc7W2a85S"
-        - name: "Masâra-Ládo — Air skills (-5 EML)"
-          type: sohleffectdata
-          _id: AX72wr00MbISUweo
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!IxhlQpnsJvoz4FK5.Gp8ELCwrc7W2a85S"
+    - name: "Masâra-Ládo — Air skills (-5 EML)"
+      type: sohleffectdata
+      _id: AX72wr00MbISUweo
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!IxhlQpnsJvoz4FK5.AX72wr00MbISUweo"
-        - name: "Masâra-Ládo — Spirit skills (+5 EML)"
-          type: sohleffectdata
-          _id: 7IEbgXM1lCYoSVYz
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!IxhlQpnsJvoz4FK5.AX72wr00MbISUweo"
+    - name: "Masâra-Ládo — Spirit skills (+5 EML)"
+      type: sohleffectdata
+      _id: 7IEbgXM1lCYoSVYz
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!IxhlQpnsJvoz4FK5.7IEbgXM1lCYoSVYz"
-        - name: "Masâra-Ládo — Water skills (+15 EML)"
-          type: sohleffectdata
-          _id: xwUHJcGTBPzCpfkk
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!IxhlQpnsJvoz4FK5.7IEbgXM1lCYoSVYz"
+    - name: "Masâra-Ládo — Water skills (+15 EML)"
+      type: sohleffectdata
+      _id: xwUHJcGTBPzCpfkk
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!IxhlQpnsJvoz4FK5.xwUHJcGTBPzCpfkk"
+      _key: "!items.effects!IxhlQpnsJvoz4FK5.xwUHJcGTBPzCpfkk"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Masara.md
+++ b/assets/content/Mysteries/Sunsigns/Masara.md
@@ -23,79 +23,79 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Masâra — Earth skills (+5 EML)"
-          type: sohleffectdata
-          _id: h1eeRzpLCmt568NP
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Masâra — Earth skills (+5 EML)"
+      type: sohleffectdata
+      _id: h1eeRzpLCmt568NP
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!hTjG4MP2ILxzInZ1.h1eeRzpLCmt568NP"
-        - name: "Masâra — Metal skills (-5 EML)"
-          type: sohleffectdata
-          _id: gGuuSdhU1mtKRFKT
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!hTjG4MP2ILxzInZ1.h1eeRzpLCmt568NP"
+    - name: "Masâra — Metal skills (-5 EML)"
+      type: sohleffectdata
+      _id: gGuuSdhU1mtKRFKT
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!hTjG4MP2ILxzInZ1.gGuuSdhU1mtKRFKT"
-        - name: "Masâra — Fire skills (-15 EML)"
-          type: sohleffectdata
-          _id: pVOwkacavWBZwwOm
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!hTjG4MP2ILxzInZ1.gGuuSdhU1mtKRFKT"
+    - name: "Masâra — Fire skills (-15 EML)"
+      type: sohleffectdata
+      _id: pVOwkacavWBZwwOm
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-15"
                 priority: null
-          _key: "!items.effects!hTjG4MP2ILxzInZ1.pVOwkacavWBZwwOm"
-        - name: "Masâra — Air skills (-5 EML)"
-          type: sohleffectdata
-          _id: 7jbCGrUgRbcCFSbV
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!hTjG4MP2ILxzInZ1.pVOwkacavWBZwwOm"
+    - name: "Masâra — Air skills (-5 EML)"
+      type: sohleffectdata
+      _id: 7jbCGrUgRbcCFSbV
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!hTjG4MP2ILxzInZ1.7jbCGrUgRbcCFSbV"
-        - name: "Masâra — Spirit skills (+5 EML)"
-          type: sohleffectdata
-          _id: Apy5019SAUMLepRS
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!hTjG4MP2ILxzInZ1.7jbCGrUgRbcCFSbV"
+    - name: "Masâra — Spirit skills (+5 EML)"
+      type: sohleffectdata
+      _id: Apy5019SAUMLepRS
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!hTjG4MP2ILxzInZ1.Apy5019SAUMLepRS"
-        - name: "Masâra — Water skills (+15 EML)"
-          type: sohleffectdata
-          _id: Pos2f7LeD68tMusn
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!hTjG4MP2ILxzInZ1.Apy5019SAUMLepRS"
+    - name: "Masâra — Water skills (+15 EML)"
+      type: sohleffectdata
+      _id: Pos2f7LeD68tMusn
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!hTjG4MP2ILxzInZ1.Pos2f7LeD68tMusn"
+      _key: "!items.effects!hTjG4MP2ILxzInZ1.Pos2f7LeD68tMusn"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Nadai-Hirin.md
+++ b/assets/content/Mysteries/Sunsigns/Nadai-Hirin.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Nadái-Hîrin — Earth skills (-10 EML)"
-          type: sohleffectdata
-          _id: CqTNP9U9T4TbHeYp
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Nadái-Hîrin — Earth skills (-10 EML)"
+      type: sohleffectdata
+      _id: CqTNP9U9T4TbHeYp
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!xAbc5b0dM5lVNQj0.CqTNP9U9T4TbHeYp"
-        - name: "Nadái-Hîrin — Fire skills (+10 EML)"
-          type: sohleffectdata
-          _id: Td1sxOecudQq8Zn6
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!xAbc5b0dM5lVNQj0.CqTNP9U9T4TbHeYp"
+    - name: "Nadái-Hîrin — Fire skills (+10 EML)"
+      type: sohleffectdata
+      _id: Td1sxOecudQq8Zn6
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!xAbc5b0dM5lVNQj0.Td1sxOecudQq8Zn6"
-        - name: "Nadái-Hîrin — Air skills (+15 EML)"
-          type: sohleffectdata
-          _id: 9AjgyKwejUxmyWBf
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!xAbc5b0dM5lVNQj0.Td1sxOecudQq8Zn6"
+    - name: "Nadái-Hîrin — Air skills (+15 EML)"
+      type: sohleffectdata
+      _id: 9AjgyKwejUxmyWBf
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!xAbc5b0dM5lVNQj0.9AjgyKwejUxmyWBf"
-        - name: "Nadái-Hîrin — Spirit skills (+5 EML)"
-          type: sohleffectdata
-          _id: CHm7OUF8BM59cLpX
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!xAbc5b0dM5lVNQj0.9AjgyKwejUxmyWBf"
+    - name: "Nadái-Hîrin — Spirit skills (+5 EML)"
+      type: sohleffectdata
+      _id: CHm7OUF8BM59cLpX
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!xAbc5b0dM5lVNQj0.CHm7OUF8BM59cLpX"
-        - name: "Nadái-Hîrin — Water skills (-5 EML)"
-          type: sohleffectdata
-          _id: 0Irw7mClS4KEznS8
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!xAbc5b0dM5lVNQj0.CHm7OUF8BM59cLpX"
+    - name: "Nadái-Hîrin — Water skills (-5 EML)"
+      type: sohleffectdata
+      _id: 0Irw7mClS4KEznS8
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!xAbc5b0dM5lVNQj0.0Irw7mClS4KEznS8"
+      _key: "!items.effects!xAbc5b0dM5lVNQj0.0Irw7mClS4KEznS8"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Nadai.md
+++ b/assets/content/Mysteries/Sunsigns/Nadai.md
@@ -23,55 +23,55 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Nadái — Earth skills (-10 EML)"
-          type: sohleffectdata
-          _id: rxmiEICiRtkSS30C
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Nadái — Earth skills (-10 EML)"
+      type: sohleffectdata
+      _id: rxmiEICiRtkSS30C
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!8Tp4mlHIyLSiiibp.rxmiEICiRtkSS30C"
-        - name: "Nadái — Fire skills (+10 EML)"
-          type: sohleffectdata
-          _id: YEPEBrLdmEivPK52
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!8Tp4mlHIyLSiiibp.rxmiEICiRtkSS30C"
+    - name: "Nadái — Fire skills (+10 EML)"
+      type: sohleffectdata
+      _id: YEPEBrLdmEivPK52
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!8Tp4mlHIyLSiiibp.YEPEBrLdmEivPK52"
-        - name: "Nadái — Air skills (+10 EML)"
-          type: sohleffectdata
-          _id: dem6Si1wGf9uDTWm
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!8Tp4mlHIyLSiiibp.YEPEBrLdmEivPK52"
+    - name: "Nadái — Air skills (+10 EML)"
+      type: sohleffectdata
+      _id: dem6Si1wGf9uDTWm
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!8Tp4mlHIyLSiiibp.dem6Si1wGf9uDTWm"
-        - name: "Nadái — Water skills (-10 EML)"
-          type: sohleffectdata
-          _id: FDqO2OUHHSYipJsR
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!8Tp4mlHIyLSiiibp.dem6Si1wGf9uDTWm"
+    - name: "Nadái — Water skills (-10 EML)"
+      type: sohleffectdata
+      _id: FDqO2OUHHSYipJsR
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!8Tp4mlHIyLSiiibp.FDqO2OUHHSYipJsR"
+      _key: "!items.effects!8Tp4mlHIyLSiiibp.FDqO2OUHHSYipJsR"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Skorus-Masara.md
+++ b/assets/content/Mysteries/Sunsigns/Skorus-Masara.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Skôrus-Masâra — Earth skills (+5 EML)"
-          type: sohleffectdata
-          _id: ly8QosL1J7p7Ga4k
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Skôrus-Masâra — Earth skills (+5 EML)"
+      type: sohleffectdata
+      _id: ly8QosL1J7p7Ga4k
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!Hjv8cFoLgH5ywN7B.ly8QosL1J7p7Ga4k"
-        - name: "Skôrus-Masâra — Metal skills (-5 EML)"
-          type: sohleffectdata
-          _id: umqPDUr3jrdH2W5f
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!Hjv8cFoLgH5ywN7B.ly8QosL1J7p7Ga4k"
+    - name: "Skôrus-Masâra — Metal skills (-5 EML)"
+      type: sohleffectdata
+      _id: umqPDUr3jrdH2W5f
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!Hjv8cFoLgH5ywN7B.umqPDUr3jrdH2W5f"
-        - name: "Skôrus-Masâra — Fire skills (-10 EML)"
-          type: sohleffectdata
-          _id: 9AI8tEOclDDCpKVD
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!Hjv8cFoLgH5ywN7B.umqPDUr3jrdH2W5f"
+    - name: "Skôrus-Masâra — Fire skills (-10 EML)"
+      type: sohleffectdata
+      _id: 9AI8tEOclDDCpKVD
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!Hjv8cFoLgH5ywN7B.9AI8tEOclDDCpKVD"
-        - name: "Skôrus-Masâra — Spirit skills (+10 EML)"
-          type: sohleffectdata
-          _id: AWOIoWIVxq89nHFb
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!Hjv8cFoLgH5ywN7B.9AI8tEOclDDCpKVD"
+    - name: "Skôrus-Masâra — Spirit skills (+10 EML)"
+      type: sohleffectdata
+      _id: AWOIoWIVxq89nHFb
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!Hjv8cFoLgH5ywN7B.AWOIoWIVxq89nHFb"
-        - name: "Skôrus-Masâra — Water skills (+15 EML)"
-          type: sohleffectdata
-          _id: Y8TSP63fCBfuMHo7
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!Hjv8cFoLgH5ywN7B.AWOIoWIVxq89nHFb"
+    - name: "Skôrus-Masâra — Water skills (+15 EML)"
+      type: sohleffectdata
+      _id: Y8TSP63fCBfuMHo7
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!Hjv8cFoLgH5ywN7B.Y8TSP63fCBfuMHo7"
+      _key: "!items.effects!Hjv8cFoLgH5ywN7B.Y8TSP63fCBfuMHo7"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Skorus.md
+++ b/assets/content/Mysteries/Sunsigns/Skorus.md
@@ -23,55 +23,55 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Skôrus — Metal skills (-10 EML)"
-          type: sohleffectdata
-          _id: 6XoMjkowVYtYVaQh
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+effects:
+    - name: "Skôrus — Metal skills (-10 EML)"
+      type: sohleffectdata
+      _id: 6XoMjkowVYtYVaQh
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!klMQI7Di94TBMgQR.6XoMjkowVYtYVaQh"
-        - name: "Skôrus — Fire skills (-10 EML)"
-          type: sohleffectdata
-          _id: ddx5BaGLMUKBgDMC
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!klMQI7Di94TBMgQR.6XoMjkowVYtYVaQh"
+    - name: "Skôrus — Fire skills (-10 EML)"
+      type: sohleffectdata
+      _id: ddx5BaGLMUKBgDMC
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!klMQI7Di94TBMgQR.ddx5BaGLMUKBgDMC"
-        - name: "Skôrus — Spirit skills (+10 EML)"
-          type: sohleffectdata
-          _id: KH3yaJ0GZqOhku3z
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!klMQI7Di94TBMgQR.ddx5BaGLMUKBgDMC"
+    - name: "Skôrus — Spirit skills (+10 EML)"
+      type: sohleffectdata
+      _id: KH3yaJ0GZqOhku3z
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!klMQI7Di94TBMgQR.KH3yaJ0GZqOhku3z"
-        - name: "Skôrus — Water skills (+10 EML)"
-          type: sohleffectdata
-          _id: r8DtQLsawkPzcMaj
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!klMQI7Di94TBMgQR.KH3yaJ0GZqOhku3z"
+    - name: "Skôrus — Water skills (+10 EML)"
+      type: sohleffectdata
+      _id: r8DtQLsawkPzcMaj
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!klMQI7Di94TBMgQR.r8DtQLsawkPzcMaj"
+      _key: "!items.effects!klMQI7Di94TBMgQR.r8DtQLsawkPzcMaj"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Tai-Skorus.md
+++ b/assets/content/Mysteries/Sunsigns/Tai-Skorus.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Tai-Skôrus — Metal skills (-10 EML)"
-          type: sohleffectdata
-          _id: lasUp4J9YLxvJ4xu
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+effects:
+    - name: "Tai-Skôrus — Metal skills (-10 EML)"
+      type: sohleffectdata
+      _id: lasUp4J9YLxvJ4xu
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!RkYBc011zgoDKlc9.lasUp4J9YLxvJ4xu"
-        - name: "Tai-Skôrus — Fire skills (-5 EML)"
-          type: sohleffectdata
-          _id: UZwMWTaW0JCLzmJ0
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!RkYBc011zgoDKlc9.lasUp4J9YLxvJ4xu"
+    - name: "Tai-Skôrus — Fire skills (-5 EML)"
+      type: sohleffectdata
+      _id: UZwMWTaW0JCLzmJ0
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!RkYBc011zgoDKlc9.UZwMWTaW0JCLzmJ0"
-        - name: "Tai-Skôrus — Air skills (+5 EML)"
-          type: sohleffectdata
-          _id: k1wGwsRsC70RTjIW
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!RkYBc011zgoDKlc9.UZwMWTaW0JCLzmJ0"
+    - name: "Tai-Skôrus — Air skills (+5 EML)"
+      type: sohleffectdata
+      _id: k1wGwsRsC70RTjIW
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!RkYBc011zgoDKlc9.k1wGwsRsC70RTjIW"
-        - name: "Tai-Skôrus — Spirit skills (+15 EML)"
-          type: sohleffectdata
-          _id: O7SU41BMDmIPhaFy
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!RkYBc011zgoDKlc9.k1wGwsRsC70RTjIW"
+    - name: "Tai-Skôrus — Spirit skills (+15 EML)"
+      type: sohleffectdata
+      _id: O7SU41BMDmIPhaFy
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!RkYBc011zgoDKlc9.O7SU41BMDmIPhaFy"
-        - name: "Tai-Skôrus — Water skills (+10 EML)"
-          type: sohleffectdata
-          _id: zB61HMEg3vf4HKtW
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!RkYBc011zgoDKlc9.O7SU41BMDmIPhaFy"
+    - name: "Tai-Skôrus — Water skills (+10 EML)"
+      type: sohleffectdata
+      _id: zB61HMEg3vf4HKtW
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!RkYBc011zgoDKlc9.zB61HMEg3vf4HKtW"
+      _key: "!items.effects!RkYBc011zgoDKlc9.zB61HMEg3vf4HKtW"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Tai.md
+++ b/assets/content/Mysteries/Sunsigns/Tai.md
@@ -23,79 +23,79 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Tai — Earth skills (-5 EML)"
-          type: sohleffectdata
-          _id: x4Vq98CXNkJ7nlEP
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Tai — Earth skills (-5 EML)"
+      type: sohleffectdata
+      _id: x4Vq98CXNkJ7nlEP
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!BA1LewIR8VJMqbag.x4Vq98CXNkJ7nlEP"
-        - name: "Tai — Metal skills (-15 EML)"
-          type: sohleffectdata
-          _id: qX0krZZJ3kIgpHHf
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!BA1LewIR8VJMqbag.x4Vq98CXNkJ7nlEP"
+    - name: "Tai — Metal skills (-15 EML)"
+      type: sohleffectdata
+      _id: qX0krZZJ3kIgpHHf
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-15"
                 priority: null
-          _key: "!items.effects!BA1LewIR8VJMqbag.qX0krZZJ3kIgpHHf"
-        - name: "Tai — Fire skills (-5 EML)"
-          type: sohleffectdata
-          _id: LgoOLgLNU4kCzX8U
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!BA1LewIR8VJMqbag.qX0krZZJ3kIgpHHf"
+    - name: "Tai — Fire skills (-5 EML)"
+      type: sohleffectdata
+      _id: LgoOLgLNU4kCzX8U
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!BA1LewIR8VJMqbag.LgoOLgLNU4kCzX8U"
-        - name: "Tai — Air skills (+5 EML)"
-          type: sohleffectdata
-          _id: OIUG7FIAODwJpcfh
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!BA1LewIR8VJMqbag.LgoOLgLNU4kCzX8U"
+    - name: "Tai — Air skills (+5 EML)"
+      type: sohleffectdata
+      _id: OIUG7FIAODwJpcfh
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!BA1LewIR8VJMqbag.OIUG7FIAODwJpcfh"
-        - name: "Tai — Spirit skills (+15 EML)"
-          type: sohleffectdata
-          _id: AkQby1GNrmXxcCbl
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!BA1LewIR8VJMqbag.OIUG7FIAODwJpcfh"
+    - name: "Tai — Spirit skills (+15 EML)"
+      type: sohleffectdata
+      _id: AkQby1GNrmXxcCbl
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!BA1LewIR8VJMqbag.AkQby1GNrmXxcCbl"
-        - name: "Tai — Water skills (+5 EML)"
-          type: sohleffectdata
-          _id: 15hcBaf4704yOXXU
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!BA1LewIR8VJMqbag.AkQby1GNrmXxcCbl"
+    - name: "Tai — Water skills (+5 EML)"
+      type: sohleffectdata
+      _id: 15hcBaf4704yOXXU
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!BA1LewIR8VJMqbag.15hcBaf4704yOXXU"
+      _key: "!items.effects!BA1LewIR8VJMqbag.15hcBaf4704yOXXU"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Tarael-Tai.md
+++ b/assets/content/Mysteries/Sunsigns/Tarael-Tai.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Táræl-Tai — Earth skills (-5 EML)"
-          type: sohleffectdata
-          _id: H5GTWbQ5BJ3BYwxE
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Táræl-Tai — Earth skills (-5 EML)"
+      type: sohleffectdata
+      _id: H5GTWbQ5BJ3BYwxE
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!tdc6S9CPTVAHpccG.H5GTWbQ5BJ3BYwxE"
-        - name: "Táræl-Tai — Metal skills (-10 EML)"
-          type: sohleffectdata
-          _id: QEkLnY1nbSoaeuCh
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!tdc6S9CPTVAHpccG.H5GTWbQ5BJ3BYwxE"
+    - name: "Táræl-Tai — Metal skills (-10 EML)"
+      type: sohleffectdata
+      _id: QEkLnY1nbSoaeuCh
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!tdc6S9CPTVAHpccG.QEkLnY1nbSoaeuCh"
-        - name: "Táræl-Tai — Air skills (+10 EML)"
-          type: sohleffectdata
-          _id: ztmD2373TPurk2kB
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!tdc6S9CPTVAHpccG.QEkLnY1nbSoaeuCh"
+    - name: "Táræl-Tai — Air skills (+10 EML)"
+      type: sohleffectdata
+      _id: ztmD2373TPurk2kB
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!tdc6S9CPTVAHpccG.ztmD2373TPurk2kB"
-        - name: "Táræl-Tai — Spirit skills (+15 EML)"
-          type: sohleffectdata
-          _id: c4rnyIE5E1Kk4Cey
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!tdc6S9CPTVAHpccG.ztmD2373TPurk2kB"
+    - name: "Táræl-Tai — Spirit skills (+15 EML)"
+      type: sohleffectdata
+      _id: c4rnyIE5E1Kk4Cey
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!tdc6S9CPTVAHpccG.c4rnyIE5E1Kk4Cey"
-        - name: "Táræl-Tai — Water skills (+5 EML)"
-          type: sohleffectdata
-          _id: DqfurFpfpOVqfWL8
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!tdc6S9CPTVAHpccG.c4rnyIE5E1Kk4Cey"
+    - name: "Táræl-Tai — Water skills (+5 EML)"
+      type: sohleffectdata
+      _id: DqfurFpfpOVqfWL8
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!tdc6S9CPTVAHpccG.DqfurFpfpOVqfWL8"
+      _key: "!items.effects!tdc6S9CPTVAHpccG.DqfurFpfpOVqfWL8"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Tarael.md
+++ b/assets/content/Mysteries/Sunsigns/Tarael.md
@@ -23,55 +23,55 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Táræl — Earth skills (-10 EML)"
-          type: sohleffectdata
-          _id: R5K0zb2ekAReVud4
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Táræl — Earth skills (-10 EML)"
+      type: sohleffectdata
+      _id: R5K0zb2ekAReVud4
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!OM8f6ntS6Ro08wSH.R5K0zb2ekAReVud4"
-        - name: "Táræl — Metal skills (-10 EML)"
-          type: sohleffectdata
-          _id: JYiKTQgqOuGBew9v
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!OM8f6ntS6Ro08wSH.R5K0zb2ekAReVud4"
+    - name: "Táræl — Metal skills (-10 EML)"
+      type: sohleffectdata
+      _id: JYiKTQgqOuGBew9v
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!OM8f6ntS6Ro08wSH.JYiKTQgqOuGBew9v"
-        - name: "Táræl — Air skills (+10 EML)"
-          type: sohleffectdata
-          _id: irdviO9cQLETxXwh
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!OM8f6ntS6Ro08wSH.JYiKTQgqOuGBew9v"
+    - name: "Táræl — Air skills (+10 EML)"
+      type: sohleffectdata
+      _id: irdviO9cQLETxXwh
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!OM8f6ntS6Ro08wSH.irdviO9cQLETxXwh"
-        - name: "Táræl — Spirit skills (+10 EML)"
-          type: sohleffectdata
-          _id: flw6c7dgKEOihmaq
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!OM8f6ntS6Ro08wSH.irdviO9cQLETxXwh"
+    - name: "Táræl — Spirit skills (+10 EML)"
+      type: sohleffectdata
+      _id: flw6c7dgKEOihmaq
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!OM8f6ntS6Ro08wSH.flw6c7dgKEOihmaq"
+      _key: "!items.effects!OM8f6ntS6Ro08wSH.flw6c7dgKEOihmaq"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Ulandus-Aralius.md
+++ b/assets/content/Mysteries/Sunsigns/Ulandus-Aralius.md
@@ -23,67 +23,67 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Ùlándus-Arálius — Earth skills (+15 EML)"
-          type: sohleffectdata
-          _id: 7Af9miM7i0r8e8fy
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Ùlándus-Arálius — Earth skills (+15 EML)"
+      type: sohleffectdata
+      _id: 7Af9miM7i0r8e8fy
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!Cx98NqPIY4BNzuja.7Af9miM7i0r8e8fy"
-        - name: "Ùlándus-Arálius — Metal skills (+10 EML)"
-          type: sohleffectdata
-          _id: ifdqCQB79Pd5I30x
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!Cx98NqPIY4BNzuja.7Af9miM7i0r8e8fy"
+    - name: "Ùlándus-Arálius — Metal skills (+10 EML)"
+      type: sohleffectdata
+      _id: ifdqCQB79Pd5I30x
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "10"
                 priority: null
-          _key: "!items.effects!Cx98NqPIY4BNzuja.ifdqCQB79Pd5I30x"
-        - name: "Ùlándus-Arálius — Air skills (-10 EML)"
-          type: sohleffectdata
-          _id: GKHfXPsuTCklqSha
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!Cx98NqPIY4BNzuja.ifdqCQB79Pd5I30x"
+    - name: "Ùlándus-Arálius — Air skills (-10 EML)"
+      type: sohleffectdata
+      _id: GKHfXPsuTCklqSha
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-10"
                 priority: null
-          _key: "!items.effects!Cx98NqPIY4BNzuja.GKHfXPsuTCklqSha"
-        - name: "Ùlándus-Arálius — Spirit skills (-5 EML)"
-          type: sohleffectdata
-          _id: cbe9dc44eK5tP570
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!Cx98NqPIY4BNzuja.GKHfXPsuTCklqSha"
+    - name: "Ùlándus-Arálius — Spirit skills (-5 EML)"
+      type: sohleffectdata
+      _id: cbe9dc44eK5tP570
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!Cx98NqPIY4BNzuja.cbe9dc44eK5tP570"
-        - name: "Ùlándus-Arálius — Water skills (+5 EML)"
-          type: sohleffectdata
-          _id: 7duRWyQfWrTWV9f7
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!Cx98NqPIY4BNzuja.cbe9dc44eK5tP570"
+    - name: "Ùlándus-Arálius — Water skills (+5 EML)"
+      type: sohleffectdata
+      _id: 7duRWyQfWrTWV9f7
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!Cx98NqPIY4BNzuja.7duRWyQfWrTWV9f7"
+      _key: "!items.effects!Cx98NqPIY4BNzuja.7duRWyQfWrTWV9f7"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/assets/content/Mysteries/Sunsigns/Ulandus.md
+++ b/assets/content/Mysteries/Sunsigns/Ulandus.md
@@ -23,79 +23,79 @@ sohl:
     charges:
         value: null
         max: null
-    effects:
-        - name: "Ùlándus — Earth skills (+15 EML)"
-          type: sohleffectdata
-          _id: EgDK7uYuEqS23grF
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
+effects:
+    - name: "Ùlándus — Earth skills (+15 EML)"
+      type: sohleffectdata
+      _id: EgDK7uYuEqS23grF
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "nature" || has(itemLogic.data.shortcode, ["earth", "fyvria"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "15"
                 priority: null
-          _key: "!items.effects!N8Ne5Vh4PPOLUTlM.EgDK7uYuEqS23grF"
-        - name: "Ùlándus — Metal skills (+5 EML)"
-          type: sohleffectdata
-          _id: 1MwvnhprxGvj9Ik8
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
+      _key: "!items.effects!N8Ne5Vh4PPOLUTlM.EgDK7uYuEqS23grF"
+    - name: "Ùlándus — Metal skills (+5 EML)"
+      type: sohleffectdata
+      _id: 1MwvnhprxGvj9Ik8
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["script", "craft"]) || has(itemLogic.data.shortcode, ["metal", "jmorvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!N8Ne5Vh4PPOLUTlM.1MwvnhprxGvj9Ik8"
-        - name: "Ùlándus — Fire skills (-5 EML)"
-          type: sohleffectdata
-          _id: 4E7iUNfBnKyG0hTo
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
+      _key: "!items.effects!N8Ne5Vh4PPOLUTlM.1MwvnhprxGvj9Ik8"
+    - name: "Ùlándus — Fire skills (-5 EML)"
+      type: sohleffectdata
+      _id: 4E7iUNfBnKyG0hTo
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["combattechnique", "combat"]) || has(itemLogic.data.shortcode, ["fire", "peleahn"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!N8Ne5Vh4PPOLUTlM.4E7iUNfBnKyG0hTo"
-        - name: "Ùlándus — Air skills (-15 EML)"
-          type: sohleffectdata
-          _id: gEwUDAOMBXjRiBV5
-          system:
-              scope: skill
-              test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
+      _key: "!items.effects!N8Ne5Vh4PPOLUTlM.4E7iUNfBnKyG0hTo"
+    - name: "Ùlándus — Air skills (-15 EML)"
+      type: sohleffectdata
+      _id: gEwUDAOMBXjRiBV5
+      system:
+          scope: skill
+          test: 'itemLogic.data.subType === "physical" || has(itemLogic.data.shortcode, ["air", "lyahvi"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-15"
                 priority: null
-          _key: "!items.effects!N8Ne5Vh4PPOLUTlM.gEwUDAOMBXjRiBV5"
-        - name: "Ùlándus — Spirit skills (-5 EML)"
-          type: sohleffectdata
-          _id: rHbAOhwDRkfCkbdJ
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
+      _key: "!items.effects!N8Ne5Vh4PPOLUTlM.gEwUDAOMBXjRiBV5"
+    - name: "Ùlándus — Spirit skills (-5 EML)"
+      type: sohleffectdata
+      _id: rHbAOhwDRkfCkbdJ
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["mystical", "lore"]) || has(itemLogic.data.shortcode, ["spirit", "savorya"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "-5"
                 priority: null
-          _key: "!items.effects!N8Ne5Vh4PPOLUTlM.rHbAOhwDRkfCkbdJ"
-        - name: "Ùlándus — Water skills (+5 EML)"
-          type: sohleffectdata
-          _id: DFczGwZF5xIfN3zV
-          system:
-              scope: skill
-              test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivishe"])'
+      _key: "!items.effects!N8Ne5Vh4PPOLUTlM.rHbAOhwDRkfCkbdJ"
+    - name: "Ùlándus — Water skills (+5 EML)"
+      type: sohleffectdata
+      _id: DFczGwZF5xIfN3zV
+      system:
+          scope: skill
+          test: 'has(itemLogic.data.subType, ["language", "social"]) || has(itemLogic.data.shortcode, ["water", "odivshe"])'
           changes:
               - key: "mod:logic.masteryLevel"
                 type: add
                 value: "5"
                 priority: null
-          _key: "!items.effects!N8Ne5Vh4PPOLUTlM.DFczGwZF5xIfN3zV"
+      _key: "!items.effects!N8Ne5Vh4PPOLUTlM.DFczGwZF5xIfN3zV"
 folder: doIwpD92J7NodK9W
 
 ---

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "HarnMaster Kethira Basic Items",
   "description": "Basic items needed for playing Song of Heroic Lands in the world of Kethira",
   "version": "0.5.3",
-  "bugs": "https://github.com/toastygm/sohl-kethira-basic/issues",
+  "bugs": "https://github.com/HeroicLands/sohl-kethira-basic/issues",
   "license": "LICENSE",
   "readme": "README.md",
   "authors": [
@@ -22,7 +22,7 @@
       {
         "id": "sohl",
         "type": "system",
-        "manifest": "https://github.com/toastygm/Song-of-Heroic-Lands-FoundryVTT/releases/latest/download/system.json",
+        "manifest": "https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/releases/latest/download/system.json",
         "compatibility": {
           "minimum": "0.4.0",
           "verified": "0.4.3"
@@ -80,9 +80,9 @@
       }
     }
   ],
-  "url": "https://github.com/toastygm/sohl-kethira-basic/",
-  "manifest": "https://github.com/toastygm/sohl-kethira-basic/releases/latest/download/module.json",
-  "download": "https://github.com/toastygm/sohl-kethira-basic/releases/download/v0.5.3/module.zip",
+  "url": "https://github.com/HeroicLands/sohl-kethira-basic/",
+  "manifest": "https://github.com/HeroicLands/sohl-kethira-basic/releases/latest/download/module.json",
+  "download": "https://github.com/HeroicLands/sohl-kethira-basic/releases/download/v0.5.3/module.zip",
   "flags": {
     "allowBugReporter": true
   }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/toastygm/sohl-kethira-basic.git"
+        "url": "git+https://github.com/HeroicLands/sohl-kethira-basic.git"
     },
     "bugs": {
-        "url": "https://github.com/toastygm/sohl-kethira-basic/issues"
+        "url": "https://github.com/HeroicLands/sohl-kethira-basic/issues"
     },
     "engines": {
         "node": ">=24.0.0"


### PR DESCRIPTION
Every GitHub address in module.json named github.com/toastygm, the account
this repository was transferred away from. That covers the two Foundry reads
from a manifest -- the update-check manifest URL and the package download --
plus url, bugs, and the sohl system manifest in relationships.

Nothing was visibly broken, which is why it went unnoticed: GitHub redirects a
transferred repository indefinitely. But the redirect only holds while no
repository of the same name exists under the old account. If one is ever
created there, Foundry's update check resolves to it silently, and the
addresses it resolves are the ones that fetch and install code.

Verified all three rewritten download paths answer 200 under HeroicLands.

Also carries the same fix through README badges and package.json, so no
toastygm address remains anywhere in the repository. The package.json lines
are also fixed in #10; the two make the identical edit and merge in either
order.

Closes #11

Closes #12