### PR TITLE
fix: address the module manifest to the HeroicLands organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HârnMaster Kethira Module for Song of Heroic Lands
-[![Version (latest)](https://img.shields.io/github/v/release/toastygm/sohl-kethira-basic)](https://github.com/toastygm/sohl-kethira-basic/releases/latest)
+[![Version (latest)](https://img.shields.io/github/v/release/HeroicLands/sohl-kethira-basic)](https://github.com/HeroicLands/sohl-kethira-basic/releases/latest)
 [![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fsohl-kethira-basic&colorB=4aa94a)](https://forge-vtt.com/bazaar#package=sohl-kethira-basic)
-[![GitHub downloads (latest)](https://img.shields.io/badge/dynamic/json?label=Downloads@latest&query=assets[?(@.name.includes('zip'))].download_count&url=https://api.github.com/repos/toastygm/sohl-kethira-basic/releases/latest&color=green)](https://github.com/toastygm/sohl-kethira-basic/releases/latest)
+[![GitHub downloads (latest)](https://img.shields.io/badge/dynamic/json?label=Downloads@latest&query=assets[?(@.name.includes('zip'))].download_count&url=https://api.github.com/repos/HeroicLands/sohl-kethira-basic/releases/latest&color=green)](https://github.com/HeroicLands/sohl-kethira-basic/releases/latest)
 
 This module provides the necessary items, actors, and assets needed to play in the
 HârnWorld setting for HârnMaster Kethira.

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "HarnMaster Kethira Basic Items",
   "description": "Basic items needed for playing Song of Heroic Lands in the world of Kethira",
   "version": "0.5.3",
-  "bugs": "https://github.com/toastygm/sohl-kethira-basic/issues",
+  "bugs": "https://github.com/HeroicLands/sohl-kethira-basic/issues",
   "license": "LICENSE",
   "readme": "README.md",
   "authors": [
@@ -22,7 +22,7 @@
       {
         "id": "sohl",
         "type": "system",
-        "manifest": "https://github.com/toastygm/Song-of-Heroic-Lands-FoundryVTT/releases/latest/download/system.json",
+        "manifest": "https://github.com/HeroicLands/Song-of-Heroic-Lands-FoundryVTT/releases/latest/download/system.json",
         "compatibility": {
           "minimum": "0.4.0",
           "verified": "0.4.3"
@@ -80,9 +80,9 @@
       }
     }
   ],
-  "url": "https://github.com/toastygm/sohl-kethira-basic/",
-  "manifest": "https://github.com/toastygm/sohl-kethira-basic/releases/latest/download/module.json",
-  "download": "https://github.com/toastygm/sohl-kethira-basic/releases/download/v0.5.3/module.zip",
+  "url": "https://github.com/HeroicLands/sohl-kethira-basic/",
+  "manifest": "https://github.com/HeroicLands/sohl-kethira-basic/releases/latest/download/module.json",
+  "download": "https://github.com/HeroicLands/sohl-kethira-basic/releases/download/v0.5.3/module.zip",
   "flags": {
     "allowBugReporter": true
   }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/toastygm/sohl-kethira-basic.git"
+        "url": "git+https://github.com/HeroicLands/sohl-kethira-basic.git"
     },
     "bugs": {
-        "url": "https://github.com/toastygm/sohl-kethira-basic/issues"
+        "url": "https://github.com/HeroicLands/sohl-kethira-basic/issues"
     },
     "engines": {
         "node": ">=24.0.0"


### PR DESCRIPTION
Every GitHub address in `module.json` named `github.com/toastygm`, the account this repository was transferred away from.

| Field | Why it matters |
| --- | --- |
| `manifest` | Foundry's update check fetches this |
| `download` | Foundry installs the package from this |
| `url` | The "Project Homepage" link in Foundry's package browser |
| `bugs` | Where Foundry sends a bug report |
| `relationships.systems[].compatibility.manifest` | Where the `sohl` system is resolved from |

## Why fix something that isn't broken

Nothing is visibly broken, and that is exactly why this went unnoticed: GitHub redirects a transferred repository indefinitely. But the redirect holds only while no repository of the same name exists under the old account. If one is ever created there — by anyone — Foundry's update check resolves to it silently. The two addresses at the top of that table are the ones that **fetch and install code**, so the failure mode is not a broken link.

## Verification

All three rewritten download paths answer `200` under `HeroicLands`:

```
.../HeroicLands/sohl-kethira-basic/releases/latest/download/module.json   200
.../HeroicLands/sohl-kethira-basic/releases/download/v0.5.3/module.zip    200
.../HeroicLands/Song-of-Heroic-Lands-FoundryVTT/releases/latest/download/system.json   200
```

`module.json` and `package.json` both still parse. Already-installed copies keep updating either way — via the redirect before this lands, directly after.

## Scope

Also carries the same fix through the README badges and `package.json`, so no `toastygm` address remains anywhere in the repository.

The `package.json` lines are also fixed in #10. Both branches make the *identical* edit to the same lines, so they 3-way merge cleanly in either order.

`download` pins `v0.5.3`, so it is rewritten per release — this changes what the **next** release publishes, not what an installed copy fetches today.

Closes #11
