### PR TITLE
feat(content): retire character/creature in favour of `being`

### DIFF
--- a/assets/content/Characters/Bandits/Bandit_1.md
+++ b/assets/content/Characters/Bandits/Bandit_1.md
@@ -11,7 +11,7 @@ shortcode: bandit1
 slug: bandit-1
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_2.md
+++ b/assets/content/Characters/Bandits/Bandit_2.md
@@ -11,7 +11,7 @@ shortcode: bandit2
 slug: bandit-2
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_3.md
+++ b/assets/content/Characters/Bandits/Bandit_3.md
@@ -11,7 +11,7 @@ shortcode: bandit3
 slug: bandit-3
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_4.md
+++ b/assets/content/Characters/Bandits/Bandit_4.md
@@ -11,7 +11,7 @@ shortcode: bandit4
 slug: bandit-4
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_5.md
+++ b/assets/content/Characters/Bandits/Bandit_5.md
@@ -11,7 +11,7 @@ shortcode: bandit5
 slug: bandit-5
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_Archer_1.md
+++ b/assets/content/Characters/Bandits/Bandit_Archer_1.md
@@ -11,7 +11,7 @@ shortcode: banditarcher1
 slug: bandit-archer-1
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_Archer_2.md
+++ b/assets/content/Characters/Bandits/Bandit_Archer_2.md
@@ -11,7 +11,7 @@ shortcode: banditarcher2
 slug: bandit-archer-2
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_Archer_3.md
+++ b/assets/content/Characters/Bandits/Bandit_Archer_3.md
@@ -11,7 +11,7 @@ shortcode: banditarcher3
 slug: bandit-archer-3
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_Leader_1.md
+++ b/assets/content/Characters/Bandits/Bandit_Leader_1.md
@@ -11,7 +11,7 @@ shortcode: banditleader1
 slug: bandit-leader-1
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_Leader_2.md
+++ b/assets/content/Characters/Bandits/Bandit_Leader_2.md
@@ -11,7 +11,7 @@ shortcode: banditleader2
 slug: bandit-leader-2
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Bandits/Bandit_Leader_3.md
+++ b/assets/content/Characters/Bandits/Bandit_Leader_3.md
@@ -11,7 +11,7 @@ shortcode: banditleader3
 slug: bandit-leader-3
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/HMK_Basic_Folk.md
+++ b/assets/content/Characters/HMK_Basic_Folk.md
@@ -11,7 +11,7 @@ shortcode: hmkbasicfolk
 slug: hmk-basic-folk
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Pregens/Branwaal_al_Dorgaar.md
+++ b/assets/content/Characters/Pregens/Branwaal_al_Dorgaar.md
@@ -11,7 +11,7 @@ shortcode: branwaalaldorgaar
 slug: branwaal-al-dorgaar
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Pregens/Cheleb_al_Rhyddyn.md
+++ b/assets/content/Characters/Pregens/Cheleb_al_Rhyddyn.md
@@ -11,7 +11,7 @@ shortcode: chelebalrhyddyn
 slug: cheleb-al-rhyddyn
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Pregens/Elyse_al_Skyrn.md
+++ b/assets/content/Characters/Pregens/Elyse_al_Skyrn.md
@@ -11,7 +11,7 @@ shortcode: elysealskyrn
 slug: elyse-al-skyrn
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Pregens/Koris_al_Syndalr.md
+++ b/assets/content/Characters/Pregens/Koris_al_Syndalr.md
@@ -11,7 +11,7 @@ shortcode: korisalsyndalr
 slug: koris-al-syndalr
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Characters/Pregens/Tornis_al_Kubry.md
+++ b/assets/content/Characters/Pregens/Tornis_al_Kubry.md
@@ -11,7 +11,7 @@ shortcode: tornisalkubry
 slug: tornis-al-kubry
 img: systems/sohl/assets/icons/game-icons/delapouite/person.svg
 portrait: systems/sohl/assets/icons/game-icons/delapouite/person.svg
-type: character
+type: being
 pack: characters
 package: kethira
 social:

--- a/assets/content/Creatures/Gargun/Gargun_Arak.md
+++ b/assets/content/Creatures/Gargun/Gargun_Arak.md
@@ -13,7 +13,7 @@ shortcode: arak
 slug: gargun-arak
 img: systems/sohl/assets/icons/game-icons/delapouite/orc-head.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Gargun/Gargun_Hyeka.md
+++ b/assets/content/Creatures/Gargun/Gargun_Hyeka.md
@@ -13,7 +13,7 @@ shortcode: hyeka
 slug: gargun-hyeka
 img: systems/sohl/assets/icons/game-icons/delapouite/orc-head.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Gargun/Gargun_Khanu.md
+++ b/assets/content/Creatures/Gargun/Gargun_Khanu.md
@@ -13,7 +13,7 @@ shortcode: khanu
 slug: gargun-khanu
 img: systems/sohl/assets/icons/game-icons/delapouite/orc-head.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Gargun/Gargun_Kyani.md
+++ b/assets/content/Creatures/Gargun/Gargun_Kyani.md
@@ -13,7 +13,7 @@ shortcode: kyani
 slug: gargun-kyani
 img: systems/sohl/assets/icons/game-icons/delapouite/orc-head.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Gargun/Gargun_Viasal.md
+++ b/assets/content/Creatures/Gargun/Gargun_Viasal.md
@@ -13,7 +13,7 @@ shortcode: viasal
 slug: gargun-viasal
 img: systems/sohl/assets/icons/game-icons/delapouite/orc-head.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Ivashu/Aklash.md
+++ b/assets/content/Creatures/Ivashu/Aklash.md
@@ -11,7 +11,7 @@ shortcode: aklash
 slug: aklash
 img: systems/sohl/assets/icons/game-icons/skoll/troll.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Ivashu/Domorser.md
+++ b/assets/content/Creatures/Ivashu/Domorser.md
@@ -12,7 +12,7 @@ shortcode: domorser
 slug: domorser
 img: systems/sohl/assets/icons/game-icons/lorc/wolf-head.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Ivashu/Hru.md
+++ b/assets/content/Creatures/Ivashu/Hru.md
@@ -12,7 +12,7 @@ shortcode: hru
 slug: hru
 img: systems/sohl/assets/icons/game-icons/delapouite/rock-golem.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Ivashu/Nolah.md
+++ b/assets/content/Creatures/Ivashu/Nolah.md
@@ -13,7 +13,7 @@ shortcode: nolah
 slug: nolah
 img: systems/sohl/assets/icons/game-icons/lorc/spectre.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Ivashu/Umbath.md
+++ b/assets/content/Creatures/Ivashu/Umbath.md
@@ -14,7 +14,7 @@ shortcode: umbath
 slug: umbath
 img: systems/sohl/assets/icons/game-icons/delapouite/gargoyle.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/assets/content/Creatures/Ivashu/Vlasta.md
+++ b/assets/content/Creatures/Ivashu/Vlasta.md
@@ -13,7 +13,7 @@ shortcode: vlasta
 slug: vlasta
 img: systems/sohl/assets/icons/game-icons/lorc/bird-claw.svg
 portrait: ""
-type: creature
+type: being
 package: kethira
 sohl:
   archetype: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.5.3",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@heroiclands/content-build": "^0.3.0",
+                "@heroiclands/content-build": "^0.4.0",
                 "yaml": "^2.9.0"
             },
             "engines": {
@@ -39,9 +39,9 @@
             }
         },
         "node_modules/@heroiclands/content-build": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.3.0.tgz",
-            "integrity": "sha512-0xgIkL5jMtnz8Hci2a1OdMYKqSjh6LSkM5QSzhKTavwHlkFVo/x4p0qsQlB8fgdr88fRxoST0ve6CRXBW9Sy2w==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.4.0.tgz",
+            "integrity": "sha512-GhLp4Ldm7ca9GxVDIkbB0NJW9iQSXzd6e0BNeuqFlDSN8kEULnEp1xbzj/QyL0ZyD73BqYE+tEDaHr4PCe+YLA==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "lint:labels": "node utils/check-labels.mjs"
     },
     "devDependencies": {
-        "@heroiclands/content-build": "^0.3.0",
+        "@heroiclands/content-build": "^0.4.0",
         "yaml": "^2.9.0"
     }
 }


### PR DESCRIPTION
`character` and `creature` compiled to the same Foundry `being` and nothing in
the toolchain branched on which name a note declared. They are retired in favour
of the single type they always produced (HeroicLands/content-build#5), and this
repository's 28 actor notes move with them: 17 under `Characters/` and 11 under
`Creatures/`.

**This is the cheapest of the three content migrations, because nothing is
downstream of it here.** No `actors` pack is configured, so these notes compiled
to nothing before and compile to nothing now; `publish.site` is false, so no URL
moves and no redirect is owed; there are no `[[character-…]]` / `[[creature-…]]`
wikilinks anywhere in the tree; and `manifests.publish` is false, so no other
package resolves these addresses. The work is 28 `type:` values and the pin.

`characters` in `module.json` is a **pack name**, not a content type — the Actor
compendium that ships empty and stays declared so existing worlds' UUIDs keep
resolving. Untouched.

**Verified byte-for-byte.** The two Item packs were compiled from `main` on the
old toolchain and from this branch on the new one, and `diff -r` over the
generated JSON reports no difference at all — 353 files, identical. That is the
whole claim this change makes about the packs.

Also verified that the retirement fails loudly rather than quietly: compiling the
pre-migration tree against the new toolchain stops with

    Content type "creature" was retired in favour of "being" —
    …/assets/content/Creatures/Ivashu/Aklash.md.

naming the file and the fix, instead of skipping the note in silence as every
pass would otherwise have done.

Not touched: 131 files under `assets/content/` are not Prettier-clean, 17 of them
among the notes edited here. That drift is identical on `main` — this change
neither caused nor widened it — and the repository has no `format` script and no
formatting gate in CI, so there is nothing here to satisfy. Reformatting 17 files
would have buried a 28-line diff. Filed separately.

Closes #17
