### PR TITLE
task(devops): watch dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot version updates.
+#
+# Labels are pinned to `devops` deliberately. Dependabot's own default label is
+# `dependencies`, which is not in `.github/labels.yml` — and that registry is a
+# closed set, so `labels-sync.yml` would delete the label again on the next push
+# to `main`. Naming a managed label keeps the two from fighting.
+#
+# Routine minor and patch bumps are grouped by dependency type. A major bump is
+# a decision, not housekeeping, so it arrives as its own pull request with its
+# own changelog to read.
+#
+# That reasoning inverts below 1.0, which is where the toolchain sits. A `0.x`
+# package signals a breaking change with a **minor** bump — `0.4.0` to `0.5.0`
+# is the break — and the major rule never fires, because `1.0.0` never arrives.
+# So `@heroiclands/content-build` is matched ahead of the catch-alls and never
+# grouped. Its 0.4.0 really was a breaking release, and this module's pin had to
+# be moved to it by hand. See #20.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - devops
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      # The toolchain first: it is its own decision and may not be swept into a
+      # grouped housekeeping pull request. A group of one still yields one pull
+      # request, which is the point. Dependabot assigns a dependency to the
+      # first group it matches, so this entry's position is what does the work.
+      content-build:
+        patterns:
+          - "@heroiclands/content-build"
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - devops
+    commit-message:
+      prefix: chore(ci)
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This repository had no Dependabot configuration, so nothing watched its
dependencies — including `@heroiclands/content-build`, the toolchain that
compiles both of its Foundry item packs. Rendering no pages and shipping no
theme, that is the only first-party dependency it has, which makes it the whole
of what there was to watch rather than a minor part of it.

The caret is the sharp edge: on a `0.x` version it does **not** cross a minor.
That is not hypothetical — the pin was `^0.3.0` and had to be moved to `^0.4.0`
by hand in #18, because nothing would have moved it.

Covers `npm` and `github-actions`, weekly.

**`@heroiclands/content-build` gets its own pull request**, matched ahead of the
grouped catch-alls. Under semver a `0.x` package signals a breaking change with
a *minor* bump, so a grouped "minor and patch" pull request would quietly carry
a breaking toolchain change — and 0.4.0 genuinely was one, retiring two content
types and turning five constant exports into accessor functions. Order is what
enforces it: Dependabot assigns a dependency to the first group it matches. The
same correction is being made in the system repository
(HeroicLands/Song-of-Heroic-Lands-FoundryVTT#1643).

Labels are pinned to `devops` rather than Dependabot's default `dependencies`,
which is not in this repository's closed label registry — `labels-sync` would
delete it on the next push to `main`, and the two would fight indefinitely.

Closes #20
