### PR TITLE
chore(deps): bump @heroiclands/content-build to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.5.3",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@heroiclands/content-build": "^0.4.0",
+                "@heroiclands/content-build": "^0.6.0",
                 "yaml": "^2.9.0"
             },
             "engines": {
@@ -39,9 +39,9 @@
             }
         },
         "node_modules/@heroiclands/content-build": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.4.0.tgz",
-            "integrity": "sha512-GhLp4Ldm7ca9GxVDIkbB0NJW9iQSXzd6e0BNeuqFlDSN8kEULnEp1xbzj/QyL0ZyD73BqYE+tEDaHr4PCe+YLA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.6.0.tgz",
+            "integrity": "sha512-xkBDKEv+7LJWThOuByjLEwGeO5vQce1GXj/mrXN+V2EGU9w0X00+S0HSqwsDD7J1FZp7z6plbxra4a/8ALE8fQ==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "lint:labels": "node utils/check-labels.mjs"
     },
     "devDependencies": {
-        "@heroiclands/content-build": "^0.4.0",
+        "@heroiclands/content-build": "^0.6.0",
         "yaml": "^2.9.0"
     }
 }


### PR DESCRIPTION
## What

`@heroiclands/content-build` **^0.4.0 → ^0.6.0**, manifest and lockfile.

The pin had to move: `^0.4.0` is `>=0.4.0 <0.5.0`, so the caret could never reach 0.6.0.

## What this verifies

0.6.0 carries four previously-unpublished changes, two of them breaking:

- `feat!` HeroicLands/content-build#11 — an item type's default art now travels with its builder
- `bug` HeroicLands/content-build#13 — an ambiguous wikilink fails the compile instead of warning

The first is the one that matters most here: it exists so a consuming repository can declare art for its own item types rather than depending on a table it cannot add to, and this repository is the case that motivated it.

Locally, against 0.6.0:

- `npm run build` — 269 items compiled (21 affiliation, 24 mystery, 224 mysticalability), both packs written, no pack churn in git
- `npm run lint` — clean

## On the ambiguity change

This repository has **no** colliding aliases at all, so the stricter rule has nothing to fire on. Checked before the release rather than found here.

## Note

Dependabot would have raised this on Monday. Doing it now rather than sitting four days behind a release with breaking changes in it. Removing the manual release step is HeroicLands/content-build#15.