### PR TITLE
chore(deps): bump @heroiclands/content-build to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.5.3",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@heroiclands/content-build": "^0.6.0",
+                "@heroiclands/content-build": "^0.7.0",
                 "yaml": "^2.9.0"
             },
             "engines": {
@@ -39,9 +39,9 @@
             }
         },
         "node_modules/@heroiclands/content-build": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.6.0.tgz",
-            "integrity": "sha512-xkBDKEv+7LJWThOuByjLEwGeO5vQce1GXj/mrXN+V2EGU9w0X00+S0HSqwsDD7J1FZp7z6plbxra4a/8ALE8fQ==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.7.0.tgz",
+            "integrity": "sha512-B/6K6kWSCQ0brzTChUodEb58WpRLhryYL8G82xSLg9GnuEc/4r8yLDc2txb8oA5cavfdwY3YVqzuOBcqRkQTxw==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "lint:labels": "node utils/check-labels.mjs"
     },
     "devDependencies": {
-        "@heroiclands/content-build": "^0.6.0",
+        "@heroiclands/content-build": "^0.7.0",
         "yaml": "^2.9.0"
     }
 }


### PR DESCRIPTION
Keeps this repository on the same toolchain as `sohl` and `sohl-thalorna`,
which both moved to 0.7.0 today.

0.7.0 brings the located build diagnostics from content-build#17: a warning
about a content note now names the file, line and column it is about
(`file:line:column: severity: message`) instead of naming the note by its
`name.full`, which is not an address. This tree currently emits none — every
wikilink resolves — so the change is latent here rather than visible, which is
the right state to be in before it isn't.

The one breaking change in 0.7.0 — `expandNoteTables` returns
`{ markdown, lineMap }` rather than the markdown string — is inert here:
nothing in this repository imports it.

Verified: `npm run build` exits 0 and compiles 66 + 269 items as before.
