### PR TITLE
chore(deps): bump @heroiclands/content-build to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.5.3",
             "license": "SEE LICENSE IN LICENSE",
             "devDependencies": {
-                "@heroiclands/content-build": "^0.7.0",
+                "@heroiclands/content-build": "^0.8.0",
                 "yaml": "^2.9.0"
             },
             "engines": {
@@ -39,9 +39,9 @@
             }
         },
         "node_modules/@heroiclands/content-build": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.7.0.tgz",
-            "integrity": "sha512-B/6K6kWSCQ0brzTChUodEb58WpRLhryYL8G82xSLg9GnuEc/4r8yLDc2txb8oA5cavfdwY3YVqzuOBcqRkQTxw==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@heroiclands/content-build/-/content-build-0.8.0.tgz",
+            "integrity": "sha512-CZdid1K9JV7QBvloOuJ+pvvfrLFyNGJWwEnurjbVzkNn194A8y9GLrAaHFFscF+64aQ58vC6WgwxfW5HT9j2Pg==",
             "dev": true,
             "license": "GPL-3.0-or-later",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "lint:labels": "node utils/check-labels.mjs"
     },
     "devDependencies": {
-        "@heroiclands/content-build": "^0.7.0",
+        "@heroiclands/content-build": "^0.8.0",
         "yaml": "^2.9.0"
     }
 }


### PR DESCRIPTION
Follows #24, which took this repository to 0.7.0.

0.8.0 is content-build#23: the mapping from a note's `sohl:` frontmatter to the
emitted `system` block is now a declared field table (`sohl/item-fields.mjs`)
rather than logic inside each builder's body. This repository takes
`ITEM_BUILDERS` from the package unchanged, so the rewrite arrives here
transparently — no configuration change, and the `fields` key an entry may now
carry is optional.

Verified byte-for-byte rather than assumed. Compiling this content tree on
0.6.0 and on 0.8.0 produces **identical** output — `diff -r` over all 353
generated pack documents reports no difference — so the builder rewrite and the
0.7.0 diagnostics change are both inert for the documents this repository
ships. `npm run build` exits 0.
